### PR TITLE
Add RPC get_introspection snapshot for assembler state and provenance

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -17,6 +17,9 @@
 - Added `formatAssembledContext()` formatter for structured XML-based context fragment injection (`context/assembler/format.ts`) ([#4](https://github.com/durch/oh-my-pi/issues/4))
 - Added explicit legacy context injection guards gated on `isLegacyActive()` for memory summary and memory startup in assembler mode ([#4](https://github.com/durch/oh-my-pi/issues/4))
 - Added assembler mode migration documentation (`docs/assembler-mode-migration.md`) ([#4](https://github.com/durch/oh-my-pi/issues/4))
+- Added RPC `get_introspection` command returning consolidated assembler state snapshot (mode, locator summary, provenance, budget, unresolved loops) for external orchestrators ([#5](https://github.com/durch/oh-my-pi/issues/5))
+- Added `RpcClient.getIntrospection()` typed helper for the new introspection endpoint ([#5](https://github.com/durch/oh-my-pi/issues/5))
+- Added `buildIntrospectionSnapshot()` in `modes/rpc/rpc-introspection.ts` with unit tests for snapshot building ([#5](https://github.com/durch/oh-my-pi/issues/5))
 - Added `thinking.ts` module with `getThinkingLevelMetadata()` and `resolveThinkingLevelForModel()` utilities for thinking level handling
 - Added `ThinkingConfig` support to model definitions for specifying supported thinking effort levels per model
 - Added `enrichModelThinking()` function to apply thinking configuration to models during registry initialization

--- a/packages/coding-agent/src/context/memory-contract.ts
+++ b/packages/coding-agent/src/context/memory-contract.ts
@@ -36,6 +36,7 @@ export const MEMORY_LOCATOR_RETRIEVAL_METHODS = [
 	"rpc.get_messages",
 	"rpc.get_branch_messages",
 	"rpc.get_last_assistant_text",
+	"rpc.get_introspection",
 	"session.getAsyncJobSnapshot",
 	"memory.read",
 ] as const;

--- a/packages/coding-agent/src/modes/rpc/rpc-client.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-client.ts
@@ -10,7 +10,7 @@ import type { BashResult } from "../../exec/bash-executor";
 import type { SessionStats } from "../../session/agent-session";
 import type { CompactionResult } from "../../session/compaction";
 import { isRpcCompatibilityAgentEventType } from "./compatibility-contract";
-import type { RpcCommand, RpcResponse, RpcSessionState } from "./rpc-types";
+import type { RpcCommand, RpcIntrospectionSnapshot, RpcResponse, RpcSessionState } from "./rpc-types";
 
 /** Distributive Omit that works with union types */
 type DistributiveOmit<T, K extends keyof T> = T extends unknown ? Omit<T, K> : never;
@@ -411,6 +411,14 @@ export class RpcClient {
 	async getMessages(): Promise<AgentMessage[]> {
 		const response = await this.#send({ type: "get_messages" });
 		return this.#getData<{ messages: AgentMessage[] }>(response).messages;
+	}
+
+	/**
+	 * Get consolidated assembler introspection snapshot.
+	 */
+	async getIntrospection(): Promise<RpcIntrospectionSnapshot> {
+		const response = await this.#send({ type: "get_introspection" });
+		return this.#getData(response);
 	}
 
 	// =========================================================================

--- a/packages/coding-agent/src/modes/rpc/rpc-introspection.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-introspection.ts
@@ -1,0 +1,81 @@
+/**
+ * Builds consolidated introspection snapshots for the get_introspection RPC command.
+ *
+ * Extracted into a standalone module for testability — the snapshot builder is
+ * a pure function over settings + bridge state.
+ */
+
+import type { Settings } from "../../config/settings";
+import type { ToolResultBridge } from "../../context/bridge";
+import { type ContextManagerState, getContextManagerState } from "../../context-manager";
+import type { RpcIntrospectionSnapshot, RpcProvenanceSummaryEntry } from "./rpc-types";
+
+/**
+ * Build a consolidated introspection snapshot from context-manager state and
+ * assembler bridge (if active).
+ */
+export function buildIntrospectionSnapshot(
+	settings: Settings,
+	bridge: ToolResultBridge | undefined,
+): RpcIntrospectionSnapshot {
+	const cmState: ContextManagerState = getContextManagerState(settings);
+	const contract = bridge?.contract ?? null;
+
+	let contractSummary: RpcIntrospectionSnapshot["contract"] = null;
+	const provenance: RpcProvenanceSummaryEntry[] = [];
+
+	if (contract) {
+		const locatorsByTier = { long_term: 0, short_term: 0, working: 0 };
+		const locatorsByTrust = { authoritative: 0, derived: 0, heuristic: 0 };
+		const provenanceMap = new Map<string, { total: number; sumConfidence: number }>();
+
+		for (const entry of contract.locatorMap) {
+			locatorsByTier[entry.tier]++;
+			locatorsByTrust[entry.trust]++;
+
+			const src = entry.provenance.source;
+			const agg = provenanceMap.get(src);
+			if (agg) {
+				agg.total++;
+				agg.sumConfidence += entry.provenance.confidence;
+			} else {
+				provenanceMap.set(src, { total: 1, sumConfidence: entry.provenance.confidence });
+			}
+		}
+
+		// Aggregate unresolved loops from all STM records
+		const unresolvedLoops: string[] = [];
+		for (const stm of contract.shortTerm) {
+			for (const loop of stm.unresolvedLoops) {
+				if (!unresolvedLoops.includes(loop)) {
+					unresolvedLoops.push(loop);
+				}
+			}
+		}
+
+		for (const [source, agg] of provenanceMap) {
+			provenance.push({
+				source,
+				count: agg.total,
+				avgConfidence: agg.sumConfidence / agg.total,
+			});
+		}
+
+		contractSummary = {
+			version: contract.version,
+			locatorCount: contract.locatorMap.length,
+			locatorsByTier,
+			locatorsByTrust,
+			shortTermRecordCount: contract.shortTerm.length,
+			unresolvedLoops,
+		};
+	}
+
+	return {
+		mode: cmState.mode,
+		assemblerActive: cmState.assemblerActive,
+		contract: contractSummary,
+		provenance,
+		budget: contract?.working?.budget ?? null,
+	};
+}

--- a/packages/coding-agent/src/modes/rpc/rpc-mode.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-mode.ts
@@ -14,6 +14,7 @@ import { readJsonl, Snowflake } from "@oh-my-pi/pi-utils";
 import type { ExtensionUIContext, ExtensionUIDialogOptions } from "../../extensibility/extensions";
 import { type Theme, theme } from "../../modes/theme/theme";
 import type { AgentSession } from "../../session/agent-session";
+import { buildIntrospectionSnapshot } from "./rpc-introspection";
 import type {
 	RpcCommand,
 	RpcExtensionUIRequest,
@@ -648,6 +649,15 @@ export async function runRpcMode(session: AgentSession): Promise<never> {
 
 			case "get_messages": {
 				return success(id, "get_messages", { messages: session.messages });
+			}
+
+			// =================================================================
+			// Introspection
+			// =================================================================
+
+			case "get_introspection": {
+				const snapshot = buildIntrospectionSnapshot(session.settings, session.assemblerBridge);
+				return success(id, "get_introspection", snapshot);
 			}
 
 			default: {

--- a/packages/coding-agent/src/modes/rpc/rpc-types.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-types.ts
@@ -6,6 +6,8 @@
  */
 import type { AgentMessage, ThinkingLevel } from "@oh-my-pi/pi-agent-core";
 import type { Effort, ImageContent, Model } from "@oh-my-pi/pi-ai";
+import type { MemoryAssemblyBudget, MemoryLocatorTrustLevel, MemoryTierName } from "../../context/memory-contract";
+import type { ContextManagerMode } from "../../context-manager";
 import type { BashResult } from "../../exec/bash-executor";
 import type { SessionStats } from "../../session/agent-session";
 import type { CompactionResult } from "../../session/compaction";
@@ -62,7 +64,10 @@ export type RpcCommand =
 	| { id?: string; type: "set_session_name"; name: string }
 
 	// Messages
-	| { id?: string; type: "get_messages" };
+	| { id?: string; type: "get_messages" }
+
+	// Introspection
+	| { id?: string; type: "get_introspection" };
 
 // ============================================================================
 // RPC State
@@ -175,8 +180,44 @@ export type RpcResponse =
 	// Messages
 	| { id?: string; type: "response"; command: "get_messages"; success: true; data: { messages: AgentMessage[] } }
 
+	// Introspection
+	| {
+			id?: string;
+			type: "response";
+			command: "get_introspection";
+			success: true;
+			data: RpcIntrospectionSnapshot;
+	  }
+
 	// Error response (any command can fail)
 	| { id?: string; type: "response"; command: string; success: false; error: string };
+
+// ============================================================================
+// Introspection
+// ============================================================================
+
+/** Aggregated provenance entry for introspection snapshots. */
+export interface RpcProvenanceSummaryEntry {
+	source: string;
+	count: number;
+	avgConfidence: number;
+}
+
+/** Consolidated assembler introspection snapshot returned by get_introspection. */
+export interface RpcIntrospectionSnapshot {
+	mode: ContextManagerMode;
+	assemblerActive: boolean;
+	contract: {
+		version: number;
+		locatorCount: number;
+		locatorsByTier: Record<MemoryTierName, number>;
+		locatorsByTrust: Record<MemoryLocatorTrustLevel, number>;
+		shortTermRecordCount: number;
+		unresolvedLoops: string[];
+	} | null;
+	provenance: RpcProvenanceSummaryEntry[];
+	budget: MemoryAssemblyBudget | null;
+}
 
 // ============================================================================
 // Extension UI Events (stdout)

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -1506,6 +1506,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		obfuscator,
 		asyncJobManager,
 		pendingActionStore,
+		assemblerBridge,
 	});
 
 	if (model?.api === "openai-codex-responses") {

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -54,6 +54,7 @@ import { MODEL_ROLE_IDS, type ModelRegistry, type ModelRole } from "../config/mo
 import { extractExplicitThinkingSelector, parseModelString, resolveModelRoleValue } from "../config/model-resolver";
 import { expandPromptTemplate, type PromptTemplate, renderPromptTemplate } from "../config/prompt-templates";
 import type { Settings, SkillsSettings } from "../config/settings";
+import type { ToolResultBridge } from "../context/bridge";
 import { type BashResult, executeBash as executeBashCommand } from "../exec/bash-executor";
 import { exportSessionToHtml } from "../export/html";
 import type { TtsrManager, TtsrMatchContext } from "../export/ttsr";
@@ -197,6 +198,8 @@ export interface AgentSessionConfig {
 	obfuscator?: SecretObfuscator;
 	/** Pending action store for preview/apply workflows */
 	pendingActionStore?: PendingActionStore;
+	/** Assembler bridge for introspection (shadow/assembler modes) */
+	assemblerBridge?: ToolResultBridge;
 }
 
 /** Options for AgentSession.prompt() */
@@ -306,6 +309,7 @@ export class AgentSession {
 	readonly agent: Agent;
 	readonly sessionManager: SessionManager;
 	readonly settings: Settings;
+	#assemblerBridge: ToolResultBridge | undefined;
 
 	#asyncJobManager: AsyncJobManager | undefined = undefined;
 	#scopedModels: Array<{ model: Model; thinkingLevel?: ThinkingLevel }>;
@@ -427,6 +431,7 @@ export class AgentSession {
 		this.#obfuscator = config.obfuscator;
 		this.agent.providerSessionState = this.#providerSessionState;
 		this.#pendingActionStore = config.pendingActionStore;
+		this.#assemblerBridge = config.assemblerBridge;
 		this.#unsubscribePendingActionPush = this.#pendingActionStore?.subscribePush(action => {
 			const reminderText = [
 				"<system-reminder>",
@@ -453,6 +458,11 @@ export class AgentSession {
 	/** Model registry for API key resolution and model discovery */
 	get modelRegistry(): ModelRegistry {
 		return this.#modelRegistry;
+	}
+
+	/** Assembler bridge for introspection (shadow/assembler modes). */
+	get assemblerBridge(): ToolResultBridge | undefined {
+		return this.#assemblerBridge;
 	}
 
 	/** Provider-scoped mutable state store for transport/session caches. */

--- a/packages/coding-agent/test/memory-contract.test.ts
+++ b/packages/coding-agent/test/memory-contract.test.ts
@@ -41,6 +41,7 @@ describe("MemoryContractV1", () => {
 			"rpc.get_messages",
 			"rpc.get_branch_messages",
 			"rpc.get_last_assistant_text",
+			"rpc.get_introspection",
 			"session.getAsyncJobSnapshot",
 			"memory.read",
 		]);

--- a/packages/coding-agent/test/rpc-introspection.test.ts
+++ b/packages/coding-agent/test/rpc-introspection.test.ts
@@ -1,0 +1,237 @@
+import { describe, expect, test } from "bun:test";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { ToolResultBridge } from "@oh-my-pi/pi-coding-agent/context/bridge";
+import { MEMORY_CONTRACT_VERSION } from "@oh-my-pi/pi-coding-agent/context/memory-contract";
+import { buildIntrospectionSnapshot } from "@oh-my-pi/pi-coding-agent/modes/rpc/rpc-introspection";
+
+const NOW = "2025-06-15T12:00:00.000Z";
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Helpers
+// ═══════════════════════════════════════════════════════════════════════════
+
+function createTestBridge(): ToolResultBridge {
+	return new ToolResultBridge({ now: NOW });
+}
+
+function legacySettings(): Settings {
+	return Settings.isolated({ "contextManager.mode": "legacy" });
+}
+
+function shadowSettings(): Settings {
+	return Settings.isolated({
+		"contextManager.mode": "shadow",
+		"memories.enabled": true,
+		"compaction.enabled": true,
+	});
+}
+
+function assemblerSettings(): Settings {
+	return Settings.isolated({
+		"contextManager.mode": "assembler",
+		"memories.enabled": false,
+		"compaction.enabled": false,
+	});
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Tests
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe("buildIntrospectionSnapshot", () => {
+	// ─────────────────────────────────────────────────────────────────────
+	// Legacy mode (no bridge)
+	// ─────────────────────────────────────────────────────────────────────
+
+	describe("legacy mode without bridge", () => {
+		test("returns legacy mode with null contract", () => {
+			const snapshot = buildIntrospectionSnapshot(legacySettings(), undefined);
+
+			expect(snapshot.mode).toBe("legacy");
+			expect(snapshot.assemblerActive).toBe(false);
+			expect(snapshot.contract).toBeNull();
+			expect(snapshot.provenance).toEqual([]);
+			expect(snapshot.budget).toBeNull();
+		});
+	});
+
+	// ─────────────────────────────────────────────────────────────────────
+	// Shadow mode with empty bridge
+	// ─────────────────────────────────────────────────────────────────────
+
+	describe("shadow mode with empty bridge", () => {
+		test("returns shadow mode with zero-count contract", () => {
+			const bridge = createTestBridge();
+			const snapshot = buildIntrospectionSnapshot(shadowSettings(), bridge);
+
+			expect(snapshot.mode).toBe("shadow");
+			expect(snapshot.assemblerActive).toBe(false);
+			expect(snapshot.contract).not.toBeNull();
+			expect(snapshot.contract!.version).toBe(MEMORY_CONTRACT_VERSION);
+			expect(snapshot.contract!.locatorCount).toBe(0);
+			expect(snapshot.contract!.locatorsByTier).toEqual({ long_term: 0, short_term: 0, working: 0 });
+			expect(snapshot.contract!.locatorsByTrust).toEqual({ authoritative: 0, derived: 0, heuristic: 0 });
+			expect(snapshot.contract!.shortTermRecordCount).toBe(1); // Bridge creates one STM record
+			expect(snapshot.contract!.unresolvedLoops).toEqual([]);
+			expect(snapshot.provenance).toEqual([]);
+			expect(snapshot.budget).toBeNull();
+		});
+	});
+
+	// ─────────────────────────────────────────────────────────────────────
+	// Assembler mode with populated bridge
+	// ─────────────────────────────────────────────────────────────────────
+
+	describe("assembler mode with populated bridge", () => {
+		test("returns assemblerActive true", () => {
+			const bridge = createTestBridge();
+			const snapshot = buildIntrospectionSnapshot(assemblerSettings(), bridge);
+
+			expect(snapshot.mode).toBe("assembler");
+			expect(snapshot.assemblerActive).toBe(true);
+		});
+
+		test("aggregates locator counts by tier and trust", () => {
+			const bridge = createTestBridge();
+
+			// Simulate tool results that generate locator entries
+			bridge.handleToolResult("read", "call-1", { path: "src/a.ts" }, "file contents", false);
+			bridge.handleToolResult("grep", "call-2", { pattern: "foo", path: "src" }, "line 1: foo", false);
+			bridge.handleToolResult("lsp", "call-3", { action: "definition", file: "src/b.ts" }, "definition info", false);
+
+			const snapshot = buildIntrospectionSnapshot(assemblerSettings(), bridge);
+
+			expect(snapshot.contract).not.toBeNull();
+			expect(snapshot.contract!.locatorCount).toBe(3);
+			// All bridge-generated entries are short_term tier
+			expect(snapshot.contract!.locatorsByTier.short_term).toBe(3);
+			expect(snapshot.contract!.locatorsByTier.long_term).toBe(0);
+			expect(snapshot.contract!.locatorsByTier.working).toBe(0);
+		});
+
+		test("aggregates provenance by source", () => {
+			const bridge = createTestBridge();
+
+			bridge.handleToolResult("read", "call-1", { path: "src/a.ts" }, "file contents", false);
+			bridge.handleToolResult("read", "call-2", { path: "src/b.ts" }, "other contents", false);
+			bridge.handleToolResult("grep", "call-3", { pattern: "foo" }, "line 1: foo", false);
+
+			const snapshot = buildIntrospectionSnapshot(assemblerSettings(), bridge);
+
+			expect(snapshot.provenance.length).toBe(2);
+
+			const readProv = snapshot.provenance.find(p => p.source === "tool:read");
+			expect(readProv).toBeDefined();
+			expect(readProv!.count).toBe(2);
+			expect(readProv!.avgConfidence).toBe(0.9);
+
+			const grepProv = snapshot.provenance.find(p => p.source === "tool:grep");
+			expect(grepProv).toBeDefined();
+			expect(grepProv!.count).toBe(1);
+		});
+
+		test("surfaces unresolved loops from error results", () => {
+			const bridge = createTestBridge();
+
+			// Errors generate unresolved loops
+			bridge.handleToolResult("bash", "call-1", { command: "make" }, "build failed", true);
+
+			const snapshot = buildIntrospectionSnapshot(assemblerSettings(), bridge);
+
+			expect(snapshot.contract).not.toBeNull();
+			expect(snapshot.contract!.unresolvedLoops.length).toBeGreaterThan(0);
+		});
+
+		test("returns null budget when working memory has none", () => {
+			const bridge = createTestBridge();
+			const snapshot = buildIntrospectionSnapshot(assemblerSettings(), bridge);
+
+			// Working memory is null by default in bridge
+			expect(snapshot.budget).toBeNull();
+		});
+	});
+
+	// ─────────────────────────────────────────────────────────────────────
+	// Payload shape
+	// ─────────────────────────────────────────────────────────────────────
+
+	describe("payload shape", () => {
+		test("snapshot has all required top-level fields", () => {
+			const snapshot = buildIntrospectionSnapshot(legacySettings(), undefined);
+
+			expect(snapshot).toHaveProperty("mode");
+			expect(snapshot).toHaveProperty("assemblerActive");
+			expect(snapshot).toHaveProperty("contract");
+			expect(snapshot).toHaveProperty("provenance");
+			expect(snapshot).toHaveProperty("budget");
+		});
+
+		test("contract summary has all required fields when present", () => {
+			const bridge = createTestBridge();
+			const snapshot = buildIntrospectionSnapshot(assemblerSettings(), bridge);
+
+			expect(snapshot.contract).toHaveProperty("version");
+			expect(snapshot.contract).toHaveProperty("locatorCount");
+			expect(snapshot.contract).toHaveProperty("locatorsByTier");
+			expect(snapshot.contract).toHaveProperty("locatorsByTrust");
+			expect(snapshot.contract).toHaveProperty("shortTermRecordCount");
+			expect(snapshot.contract).toHaveProperty("unresolvedLoops");
+		});
+
+		test("provenance entries have required fields", () => {
+			const bridge = createTestBridge();
+			bridge.handleToolResult("read", "call-1", { path: "foo.ts" }, "content", false);
+
+			const snapshot = buildIntrospectionSnapshot(assemblerSettings(), bridge);
+
+			expect(snapshot.provenance.length).toBe(1);
+			const entry = snapshot.provenance[0];
+			expect(entry).toHaveProperty("source");
+			expect(entry).toHaveProperty("count");
+			expect(entry).toHaveProperty("avgConfidence");
+			expect(typeof entry.source).toBe("string");
+			expect(typeof entry.count).toBe("number");
+			expect(typeof entry.avgConfidence).toBe("number");
+		});
+
+		test("does not include full fragment contents in response", () => {
+			const bridge = createTestBridge();
+			bridge.handleToolResult(
+				"read",
+				"call-1",
+				{ path: "large-file.ts" },
+				"x".repeat(10000), // Large content
+				false,
+			);
+
+			const snapshot = buildIntrospectionSnapshot(assemblerSettings(), bridge);
+			const json = JSON.stringify(snapshot);
+
+			// Snapshot should be bounded — no full file contents
+			expect(json.length).toBeLessThan(2000);
+		});
+	});
+
+	// ─────────────────────────────────────────────────────────────────────
+	// Mutation invalidation
+	// ─────────────────────────────────────────────────────────────────────
+
+	describe("mutation invalidation", () => {
+		test("locator count reflects invalidation after edits", () => {
+			const bridge = createTestBridge();
+
+			// Read a file, then edit it (mutation invalidates the read locator)
+			bridge.handleToolResult("read", "call-1", { path: "src/a.ts" }, "file content", false);
+			expect(bridge.contract.locatorMap.length).toBe(1);
+
+			bridge.handleToolResult("edit", "call-2", { path: "src/a.ts" }, "edit applied", false);
+			// After edit, the read locator for src/a.ts should be invalidated
+			// and the edit locator should exist
+
+			const snapshot = buildIntrospectionSnapshot(assemblerSettings(), bridge);
+
+			// Locator count should reflect post-invalidation state
+			expect(snapshot.contract!.locatorCount).toBe(bridge.contract.locatorMap.length);
+		});
+	});
+});


### PR DESCRIPTION
Closes #5

## Summary

Adds an additive RPC `get_introspection` command that returns a consolidated snapshot of assembler state, provenance, and budget usage for external orchestrators.

### Response payload

```typescript
interface RpcIntrospectionSnapshot {
  mode: "legacy" | "shadow" | "assembler";
  assemblerActive: boolean;
  contract: {
    version: number;
    locatorCount: number;
    locatorsByTier: Record<MemoryTierName, number>;
    locatorsByTrust: Record<MemoryLocatorTrustLevel, number>;
    shortTermRecordCount: number;
    unresolvedLoops: string[];
  } | null;
  provenance: Array<{ source: string; count: number; avgConfidence: number }>;
  budget: MemoryAssemblyBudget | null;
}
```

### Changes

| File | Change |
|------|--------|
| rpc-types.ts | RpcIntrospectionSnapshot, RpcProvenanceSummaryEntry types; command/response union members |
| rpc-introspection.ts | Pure buildIntrospectionSnapshot() function (new file) |
| rpc-mode.ts | get_introspection case in command dispatcher |
| rpc-client.ts | RpcClient.getIntrospection() typed method |
| agent-session.ts | assemblerBridge config field + getter |
| sdk.ts | Pass bridge to session constructor |
| memory-contract.ts | rpc.get_introspection in canonical retrieval methods |
| rpc-introspection.test.ts | 12 focused unit tests (new file) |
| memory-contract.test.ts | Updated pinned retrieval method list |

### ADR-0002 compliance

- Additive only: new command type, no changes to existing commands/events
- Compatibility contract tests pass unchanged
- RPC_COMPATIBILITY_VERSION remains at 1
