### PR TITLE
feat(coding-agent): capture canonical effective-prompt snapshots during composition

### DIFF
--- a/packages/coding-agent/src/context/effective-prompt-snapshot.ts
+++ b/packages/coding-agent/src/context/effective-prompt-snapshot.ts
@@ -1,0 +1,202 @@
+/**
+ * Canonical effective-prompt snapshot captured at composition time.
+ *
+ * Provides a single source of truth for what the model saw on a given turn,
+ * created inside the real composition path (sdk.ts transformContext) after
+ * message transformation, budget derivation, assembler packet creation,
+ * and message bounding, immediately before the model call.
+ *
+ * Downstream observability surfaces can project compact views from this
+ * canonical representation without reconstructing composition decisions.
+ */
+
+import type { AgentMessage, AgentTool } from "@oh-my-pi/pi-agent-core";
+import type { Model } from "@oh-my-pi/pi-ai";
+
+import { estimateMessageTokens, estimateToolDefinitionTokens } from "./assembler/kernel";
+import type { TransformMetadata } from "./assembler/message-transform";
+import type { MemoryAssemblyBudget, WorkingContextPacketV1 } from "./memory-contract";
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Snapshot type
+// ═══════════════════════════════════════════════════════════════════════════
+
+/** System prompt composition data within a snapshot. */
+export interface PromptSnapshotSystemPrompt {
+	/**
+	 * Stable fingerprint of the system prompt text.
+	 * Uses xxHash64 for speed; suitable for change detection, not security.
+	 */
+	fingerprint: string;
+	/** Estimated token count (chars/4 heuristic). */
+	tokenEstimate: number;
+}
+
+/** Tool definitions data within a snapshot. */
+export interface PromptSnapshotTools {
+	/** Ordered list of tool names included in the request. */
+	names: string[];
+	/** Total estimated tokens for all tool definition schemas. */
+	totalDefinitionTokenEstimate: number;
+}
+
+/** Message composition data within a snapshot. */
+export interface PromptSnapshotMessages {
+	/** The final post-transform, bounded message array sent to the model. */
+	final: AgentMessage[];
+	/** Estimated token count for the final message array. */
+	tokenEstimate: number;
+	/**
+	 * Structured transform metadata from message-transform.ts (#25).
+	 * Null when no message transform was applied (e.g., legacy mode).
+	 */
+	transformMetadata: TransformMetadata | null;
+}
+
+/** Assembler context within a snapshot (null when assembler is not active). */
+export interface PromptSnapshotAssemblerContext {
+	/** The assembled working-context packet from the kernel. */
+	packet: WorkingContextPacketV1;
+}
+
+/** Budget/headroom breakdown within a snapshot. */
+export interface PromptSnapshotBudget {
+	/** Model context window in tokens. */
+	contextWindow: number;
+	/** Tokens consumed by the system prompt. */
+	systemPromptTokens: number;
+	/** Tokens consumed by tool definitions. */
+	toolDefinitionTokens: number;
+	/** Tokens consumed by messages (post-transform). */
+	messageTokens: number;
+	/** Tokens consumed by assembled context fragments. */
+	assembledContextTokens: number;
+	/** Remaining headroom in tokens. */
+	headroom: number;
+}
+
+/**
+ * Canonical runtime snapshot of the effective prompt composition for a turn.
+ *
+ * This is the authoritative record of what the model received: system prompt
+ * fingerprint, tool definitions, final bounded messages, assembler context,
+ * budget allocation, and structured transform metadata.
+ */
+export interface EffectivePromptSnapshot {
+	/** Turn identifier (monotonic within a session). */
+	turnId: string;
+	/** ISO 8601 timestamp when the snapshot was captured. */
+	capturedAt: string;
+	/** Model used for this turn. */
+	model: {
+		provider: string;
+		id: string;
+		contextWindow: number;
+	};
+	/** System prompt composition data. */
+	systemPrompt: PromptSnapshotSystemPrompt;
+	/** Tool definitions data. */
+	tools: PromptSnapshotTools;
+	/** Message composition data. */
+	messages: PromptSnapshotMessages;
+	/** Assembler context (null when assembler is not active). */
+	assemblerContext: PromptSnapshotAssemblerContext | null;
+	/** Budget/headroom breakdown (null when budget derivation is unavailable). */
+	budget: PromptSnapshotBudget | null;
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Capture input
+// ═══════════════════════════════════════════════════════════════════════════
+
+/** Input required to capture an effective-prompt snapshot. */
+export interface CaptureSnapshotInput {
+	turnId: string;
+	model: Model | undefined;
+	systemPrompt: string;
+	tools: AgentTool[];
+	finalMessages: AgentMessage[];
+	transformMetadata: TransformMetadata | null;
+	assemblerPacket: WorkingContextPacketV1 | null;
+	assemblerBudget: MemoryAssemblyBudget | null;
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Fingerprinting
+// ═══════════════════════════════════════════════════════════════════════════
+
+/**
+ * Compute a stable fingerprint of a string using xxHash64.
+ * Not cryptographic — used for change detection only.
+ */
+export function fingerprintText(text: string): string {
+	return Bun.hash.xxHash64(text).toString(36);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Capture function
+// ═══════════════════════════════════════════════════════════════════════════
+
+/**
+ * Capture an effective-prompt snapshot from the actual runtime composition data.
+ *
+ * Called inside the transformContext closure in sdk.ts after all transformations
+ * are complete and before the messages are returned to the agent loop for the
+ * model call.
+ */
+export function captureEffectivePromptSnapshot(input: CaptureSnapshotInput): EffectivePromptSnapshot {
+	const capturedAt = new Date().toISOString();
+	const systemPromptTokens = estimateTokensFromLength(input.systemPrompt.length);
+	const toolDefinitionTokens = estimateToolDefinitionTokens(input.tools);
+	const messageTokens = estimateMessageTokens(input.finalMessages);
+	const contextWindow = input.model?.contextWindow ?? 0;
+
+	const assembledContextTokens = input.assemblerPacket?.usage.consumedTokens ?? 0;
+	const headroom = Math.max(
+		0,
+		contextWindow - systemPromptTokens - toolDefinitionTokens - messageTokens - assembledContextTokens,
+	);
+
+	return {
+		turnId: input.turnId,
+		capturedAt,
+		model: {
+			provider: input.model?.provider ?? "unknown",
+			id: input.model?.id ?? "unknown",
+			contextWindow,
+		},
+		systemPrompt: {
+			fingerprint: fingerprintText(input.systemPrompt),
+			tokenEstimate: systemPromptTokens,
+		},
+		tools: {
+			names: input.tools.map(t => t.name),
+			totalDefinitionTokenEstimate: toolDefinitionTokens,
+		},
+		messages: {
+			final: input.finalMessages,
+			tokenEstimate: messageTokens,
+			transformMetadata: input.transformMetadata,
+		},
+		assemblerContext: input.assemblerPacket ? { packet: input.assemblerPacket } : null,
+		budget: input.model
+			? {
+					contextWindow,
+					systemPromptTokens,
+					toolDefinitionTokens,
+					messageTokens,
+					assembledContextTokens,
+					headroom,
+				}
+			: null,
+	};
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Helpers
+// ═══════════════════════════════════════════════════════════════════════════
+
+/** Estimate tokens from character length using the chars/4 heuristic. */
+function estimateTokensFromLength(charCount: number): number {
+	return Math.ceil(charCount / 4);
+}

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -34,9 +34,11 @@ import {
 	estimateMessageTokens,
 	estimateToolDefinitionTokens,
 	formatAssembledContext,
+	type TransformMetadata,
 	transformMessages,
 } from "./context/assembler";
 import { ToolResultBridge } from "./context/bridge";
+import { captureEffectivePromptSnapshot, type EffectivePromptSnapshot } from "./context/effective-prompt-snapshot";
 import {
 	isAssemblerActive,
 	isLegacyActive,
@@ -229,6 +231,7 @@ export interface CreateAgentSessionResult {
 
 export type { PromptTemplate } from "./config/prompt-templates";
 export { Settings, type SkillsSettings } from "./config/settings";
+export type { EffectivePromptSnapshot } from "./context/effective-prompt-snapshot";
 export type { CustomCommand, CustomCommandFactory } from "./extensibility/custom-commands/types";
 export type { CustomTool, CustomToolFactory } from "./extensibility/custom-tools/types";
 export type * from "./extensibility/extensions";
@@ -1410,7 +1413,9 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 	// Build per-turn context transformer.
 	// In assembler mode, assembled context fragments are injected as a developer message.
 	// Extensions transform is always composed when available.
+	// All modes capture an effective-prompt snapshot for canonical observability.
 	const assemblerMode = isAssemblerActive(settings);
+	let lastPromptSnapshot: EffectivePromptSnapshot | null = null;
 	const transformContext = (() => {
 		const extensionTransform = extensionRunner
 			? (messages: AgentMessage[]) => extensionRunner.emitContext(messages)
@@ -1428,7 +1433,8 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 						// Step 1: Apply message transform (hot window + content replacement).
 						// This strips tool_result content from older turns before budget derivation
 						// so the budget reflects actual post-transform message costs.
-						const { messages: transformedMessages } = transformMessages(messages);
+						const firstPass = transformMessages(messages);
+						const transformedMessages = firstPass.messages;
 
 						const budget = currentModel
 							? deriveBudget({
@@ -1477,37 +1483,84 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 						// within the available budget.
 						const assembledContextTokens = packet.usage.consumedTokens;
 						const maxMessageTokens = budget ? Math.max(0, budget.maxTokens - assembledContextTokens) : undefined;
-						const boundedMessages =
-							maxMessageTokens !== undefined
-								? transformMessages(messages, { maxTokens: maxMessageTokens }).messages
-								: transformedMessages;
+						let boundedMessages: AgentMessage[];
+						let finalTransformMetadata: TransformMetadata;
+						if (maxMessageTokens !== undefined) {
+							const boundedPass = transformMessages(messages, { maxTokens: maxMessageTokens });
+							boundedMessages = boundedPass.messages;
+							finalTransformMetadata = boundedPass.metadata;
+						} else {
+							boundedMessages = transformedMessages;
+							finalTransformMetadata = firstPass.metadata;
+						}
 
 						// Step 4: Prepend assembled context if available.
 						const text = formatAssembledContext(packet);
-						if (text) {
-							const contextMessage: AgentMessage = {
-								role: "developer" as const,
-								content: text,
-								attribution: "agent" as const,
-								timestamp: Date.now(),
-							};
-							return [contextMessage, ...boundedMessages];
-						}
-						return boundedMessages;
+						const finalMessages = text
+							? [
+									{
+										role: "developer" as const,
+										content: text,
+										attribution: "agent" as const,
+										timestamp: Date.now(),
+									} satisfies AgentMessage,
+									...boundedMessages,
+								]
+							: boundedMessages;
+
+						// Step 5: Capture effective-prompt snapshot.
+						lastPromptSnapshot = captureEffectivePromptSnapshot({
+							turnId,
+							model: currentModel,
+							systemPrompt: currentSystemPrompt,
+							tools: currentTools,
+							finalMessages,
+							transformMetadata: finalTransformMetadata,
+							assemblerPacket: packet,
+							assemblerBudget: budget ?? null,
+						});
+
+						return finalMessages;
 					}
 				: undefined;
 
-		if (!extensionTransform && !assemblerTransform) return undefined;
-		if (extensionTransform && !assemblerTransform) {
-			return async (messages: AgentMessage[]) => extensionTransform(messages);
+		// Compose inner transform (extensions + assembler).
+		let innerTransform: ((msgs: AgentMessage[]) => Promise<AgentMessage[]>) | undefined;
+		if (extensionTransform && assemblerTransform) {
+			// Extensions first, then assembler injection
+			innerTransform = async msgs => assemblerTransform(await extensionTransform(msgs));
+		} else if (assemblerTransform) {
+			innerTransform = assemblerTransform;
+		} else if (extensionTransform) {
+			innerTransform = async msgs => extensionTransform(msgs);
 		}
-		if (!extensionTransform && assemblerTransform) {
-			return assemblerTransform;
-		}
-		// Compose: extensions first, then assembler injection
-		return async (messages: AgentMessage[]) => {
-			const afterExtensions = await extensionTransform!(messages);
-			return assemblerTransform!(afterExtensions);
+
+		// Always return a transform function to capture prompt snapshots.
+		// In assembler mode, the snapshot is captured inside assemblerTransform
+		// with full transform metadata and packet data. In non-assembler mode,
+		// a minimal snapshot is captured here with the passthrough messages.
+		return async (messages: AgentMessage[]): Promise<AgentMessage[]> => {
+			const finalMessages = innerTransform ? await innerTransform(messages) : messages;
+
+			// In non-assembler mode, capture a minimal snapshot.
+			// Assembler mode snapshot is captured inside assemblerTransform above.
+			if (!assemblerTransform) {
+				const currentModel = agent?.state.model;
+				const currentSystemPrompt = agent?.state.systemPrompt ?? "";
+				const currentTools = agent?.state.tools ?? [];
+				lastPromptSnapshot = captureEffectivePromptSnapshot({
+					turnId: `turn-${Date.now()}`,
+					model: currentModel,
+					systemPrompt: currentSystemPrompt,
+					tools: currentTools,
+					finalMessages,
+					transformMetadata: null,
+					assemblerPacket: null,
+					assemblerBudget: null,
+				});
+			}
+
+			return finalMessages;
 		};
 	})();
 
@@ -1602,6 +1655,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		asyncJobManager,
 		pendingActionStore,
 		assemblerBridge,
+		getLastPromptSnapshot: () => lastPromptSnapshot,
 	});
 
 	if (model?.api === "openai-codex-responses") {

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -55,6 +55,7 @@ import { extractExplicitThinkingSelector, parseModelString, resolveModelRoleValu
 import { expandPromptTemplate, type PromptTemplate, renderPromptTemplate } from "../config/prompt-templates";
 import type { Settings, SkillsSettings } from "../config/settings";
 import type { ToolResultBridge } from "../context/bridge";
+import type { EffectivePromptSnapshot } from "../context/effective-prompt-snapshot";
 import { type BashResult, executeBash as executeBashCommand } from "../exec/bash-executor";
 import { exportSessionToHtml } from "../export/html";
 import type { TtsrManager, TtsrMatchContext } from "../export/ttsr";
@@ -200,6 +201,8 @@ export interface AgentSessionConfig {
 	pendingActionStore?: PendingActionStore;
 	/** Assembler bridge for introspection (shadow/assembler modes) */
 	assemblerBridge?: ToolResultBridge;
+	/** Getter for the most recent effective-prompt snapshot (captured per turn by transformContext). */
+	getLastPromptSnapshot?: () => EffectivePromptSnapshot | null;
 }
 
 /** Options for AgentSession.prompt() */
@@ -310,6 +313,7 @@ export class AgentSession {
 	readonly sessionManager: SessionManager;
 	readonly settings: Settings;
 	#assemblerBridge: ToolResultBridge | undefined;
+	#getLastPromptSnapshot: (() => EffectivePromptSnapshot | null) | undefined;
 
 	#asyncJobManager: AsyncJobManager | undefined = undefined;
 	#scopedModels: Array<{ model: Model; thinkingLevel?: ThinkingLevel }>;
@@ -432,6 +436,7 @@ export class AgentSession {
 		this.agent.providerSessionState = this.#providerSessionState;
 		this.#pendingActionStore = config.pendingActionStore;
 		this.#assemblerBridge = config.assemblerBridge;
+		this.#getLastPromptSnapshot = config.getLastPromptSnapshot;
 		this.#unsubscribePendingActionPush = this.#pendingActionStore?.subscribePush(action => {
 			const reminderText = [
 				"<system-reminder>",
@@ -463,6 +468,11 @@ export class AgentSession {
 	/** Assembler bridge for introspection (shadow/assembler modes). */
 	get assemblerBridge(): ToolResultBridge | undefined {
 		return this.#assemblerBridge;
+	}
+
+	/** Most recent effective-prompt snapshot captured during composition. */
+	get lastPromptSnapshot(): EffectivePromptSnapshot | null {
+		return this.#getLastPromptSnapshot?.() ?? null;
 	}
 
 	/** Provider-scoped mutable state store for transport/session caches. */

--- a/packages/coding-agent/test/effective-prompt-snapshot.test.ts
+++ b/packages/coding-agent/test/effective-prompt-snapshot.test.ts
@@ -1,0 +1,471 @@
+import { describe, expect, test } from "bun:test";
+import type { AgentMessage, AgentTool } from "@oh-my-pi/pi-agent-core";
+import type { AssistantMessage, Model, UserMessage } from "@oh-my-pi/pi-ai";
+import type { TransformMetadata } from "@oh-my-pi/pi-coding-agent/context/assembler";
+import {
+	type CaptureSnapshotInput,
+	captureEffectivePromptSnapshot,
+	fingerprintText,
+} from "@oh-my-pi/pi-coding-agent/context/effective-prompt-snapshot";
+import {
+	MEMORY_CONTRACT_VERSION,
+	type WorkingContextPacketV1,
+} from "@oh-my-pi/pi-coding-agent/context/memory-contract";
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Test helpers
+// ═══════════════════════════════════════════════════════════════════════════
+
+let ts = 1000;
+
+function nextTimestamp(): number {
+	ts += 1000;
+	return ts;
+}
+
+function makeUser(text: string): UserMessage {
+	return {
+		role: "user",
+		content: text,
+		timestamp: nextTimestamp(),
+	};
+}
+
+function makeAssistant(text: string): AssistantMessage {
+	return {
+		role: "assistant",
+		content: [{ type: "text", text }],
+		api: "messages",
+		provider: "anthropic",
+		model: "test-model",
+		usage: {
+			input: 100,
+			output: 50,
+			cacheWrite: 0,
+			cacheRead: 0,
+			totalTokens: 150,
+			cost: { input: 0.01, output: 0.005, cacheRead: 0, cacheWrite: 0, total: 0.015 },
+		},
+		stopReason: "stop",
+		timestamp: nextTimestamp(),
+	};
+}
+
+function makeModel(overrides?: Partial<Model>): Model {
+	return {
+		name: "Claude Sonnet",
+		provider: "anthropic",
+		id: "claude-sonnet-4-20250514",
+		api: "messages",
+		contextWindow: 200_000,
+		maxTokens: 16_384,
+		baseUrl: "https://api.anthropic.com",
+		reasoning: false,
+		input: ["text", "image"],
+		cost: { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 3.75 },
+		...overrides,
+	};
+}
+
+function makeTool(name: string, description?: string, parameters?: Record<string, unknown>): AgentTool {
+	return {
+		name,
+		description: description ?? `Tool ${name}`,
+		parameters: parameters ?? { type: "object", properties: { input: { type: "string" } } },
+		execute: async () => ({ content: [{ type: "text", text: "ok" }] }),
+	} as unknown as AgentTool;
+}
+
+function makeTransformMetadata(overrides?: Partial<TransformMetadata>): TransformMetadata {
+	return {
+		decisions: [
+			{
+				turnIndex: 0,
+				action: "kept",
+				reason: "hot-window",
+				messageCount: 2,
+				hasToolResults: false,
+				tokensBefore: 50,
+				tokensAfter: 50,
+			},
+		],
+		totalTurns: 1,
+		keptCount: 1,
+		stubbedCount: 0,
+		droppedCount: 0,
+		tokensBefore: 50,
+		tokensAfter: 50,
+		...overrides,
+	};
+}
+
+function makePacket(overrides?: Partial<WorkingContextPacketV1>): WorkingContextPacketV1 {
+	return {
+		version: MEMORY_CONTRACT_VERSION,
+		objective: "test objective",
+		generatedAt: "2025-01-01T00:00:00.000Z",
+		budget: {
+			maxTokens: 40_000,
+			maxLatencyMs: 2000,
+			reservedTokens: { objective: 0, codeContext: 0, executionState: 0 },
+		},
+		usage: { consumedTokens: 500, consumedLatencyMs: 100 },
+		fragments: [
+			{
+				id: "frag-1",
+				tier: "short_term",
+				content: "function hello() {}",
+				score: 0.8,
+				provenance: {
+					source: "bridge:read",
+					reason: "tool_result",
+					capturedAt: "2025-01-01T00:00:00.000Z",
+					confidence: 1.0,
+				},
+			},
+		],
+		dropped: [],
+		...overrides,
+	};
+}
+
+function makeInput(overrides?: Partial<CaptureSnapshotInput>): CaptureSnapshotInput {
+	return {
+		turnId: "turn-1234567890",
+		model: makeModel(),
+		systemPrompt: "You are a helpful assistant.",
+		tools: [makeTool("read"), makeTool("write")],
+		finalMessages: [makeUser("Hello"), makeAssistant("Hi there!")],
+		transformMetadata: null,
+		assemblerPacket: null,
+		assemblerBudget: null,
+		...overrides,
+	};
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Tests: fingerprintText
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe("fingerprintText", () => {
+	test("produces a non-empty string", () => {
+		const fp = fingerprintText("test input");
+		expect(fp.length).toBeGreaterThan(0);
+	});
+
+	test("is deterministic", () => {
+		const input = "You are a helpful assistant with coding tools.";
+		expect(fingerprintText(input)).toBe(fingerprintText(input));
+	});
+
+	test("differs for different inputs", () => {
+		const a = fingerprintText("prompt version 1");
+		const b = fingerprintText("prompt version 2");
+		expect(a).not.toBe(b);
+	});
+
+	test("handles empty string", () => {
+		const fp = fingerprintText("");
+		expect(fp.length).toBeGreaterThan(0);
+	});
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Tests: captureEffectivePromptSnapshot
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe("captureEffectivePromptSnapshot", () => {
+	test("captures basic snapshot with correct structure", () => {
+		const input = makeInput();
+		const snapshot = captureEffectivePromptSnapshot(input);
+
+		expect(snapshot.turnId).toBe("turn-1234567890");
+		expect(snapshot.capturedAt).toBeTruthy();
+		expect(new Date(snapshot.capturedAt).getTime()).not.toBeNaN();
+	});
+
+	test("captures model information", () => {
+		const input = makeInput({ model: makeModel({ provider: "openai", id: "gpt-4o", contextWindow: 128_000 }) });
+		const snapshot = captureEffectivePromptSnapshot(input);
+
+		expect(snapshot.model.provider).toBe("openai");
+		expect(snapshot.model.id).toBe("gpt-4o");
+		expect(snapshot.model.contextWindow).toBe(128_000);
+	});
+
+	test("handles undefined model gracefully", () => {
+		const input = makeInput({ model: undefined });
+		const snapshot = captureEffectivePromptSnapshot(input);
+
+		expect(snapshot.model.provider).toBe("unknown");
+		expect(snapshot.model.id).toBe("unknown");
+		expect(snapshot.model.contextWindow).toBe(0);
+		expect(snapshot.budget).toBeNull();
+	});
+
+	test("captures system prompt fingerprint and token estimate", () => {
+		const systemPrompt = "You are a helpful coding assistant.";
+		const input = makeInput({ systemPrompt });
+		const snapshot = captureEffectivePromptSnapshot(input);
+
+		expect(snapshot.systemPrompt.fingerprint).toBe(fingerprintText(systemPrompt));
+		expect(snapshot.systemPrompt.tokenEstimate).toBe(Math.ceil(systemPrompt.length / 4));
+	});
+
+	test("system prompt fingerprint changes when prompt changes", () => {
+		const snap1 = captureEffectivePromptSnapshot(makeInput({ systemPrompt: "prompt v1" }));
+		const snap2 = captureEffectivePromptSnapshot(makeInput({ systemPrompt: "prompt v2" }));
+
+		expect(snap1.systemPrompt.fingerprint).not.toBe(snap2.systemPrompt.fingerprint);
+	});
+
+	test("captures tool names and token estimates", () => {
+		const tools = [
+			makeTool("read", "Read a file", { type: "object", properties: { path: { type: "string" } } }),
+			makeTool("write", "Write a file"),
+			makeTool("grep", "Search for patterns"),
+		];
+		const input = makeInput({ tools });
+		const snapshot = captureEffectivePromptSnapshot(input);
+
+		expect(snapshot.tools.names).toEqual(["read", "write", "grep"]);
+		expect(snapshot.tools.totalDefinitionTokenEstimate).toBeGreaterThan(0);
+	});
+
+	test("captures final messages and token estimate", () => {
+		const messages: AgentMessage[] = [
+			makeUser("Hello, can you help me?"),
+			makeAssistant("Of course! What do you need help with?"),
+			makeUser("Fix this bug."),
+		];
+		const input = makeInput({ finalMessages: messages });
+		const snapshot = captureEffectivePromptSnapshot(input);
+
+		expect(snapshot.messages.final).toBe(messages);
+		expect(snapshot.messages.final.length).toBe(3);
+		expect(snapshot.messages.tokenEstimate).toBeGreaterThan(0);
+	});
+
+	test("captures transform metadata when provided", () => {
+		const metadata = makeTransformMetadata({
+			totalTurns: 5,
+			keptCount: 3,
+			stubbedCount: 1,
+			droppedCount: 1,
+		});
+		const input = makeInput({ transformMetadata: metadata });
+		const snapshot = captureEffectivePromptSnapshot(input);
+
+		expect(snapshot.messages.transformMetadata).toBe(metadata);
+		expect(snapshot.messages.transformMetadata!.totalTurns).toBe(5);
+		expect(snapshot.messages.transformMetadata!.keptCount).toBe(3);
+		expect(snapshot.messages.transformMetadata!.stubbedCount).toBe(1);
+		expect(snapshot.messages.transformMetadata!.droppedCount).toBe(1);
+	});
+
+	test("transform metadata is null when not provided", () => {
+		const input = makeInput({ transformMetadata: null });
+		const snapshot = captureEffectivePromptSnapshot(input);
+
+		expect(snapshot.messages.transformMetadata).toBeNull();
+	});
+
+	test("captures assembler context when packet provided", () => {
+		const packet = makePacket();
+		const input = makeInput({ assemblerPacket: packet });
+		const snapshot = captureEffectivePromptSnapshot(input);
+
+		expect(snapshot.assemblerContext).not.toBeNull();
+		expect(snapshot.assemblerContext!.packet).toBe(packet);
+		expect(snapshot.assemblerContext!.packet.fragments.length).toBe(1);
+	});
+
+	test("assembler context is null when no packet", () => {
+		const input = makeInput({ assemblerPacket: null });
+		const snapshot = captureEffectivePromptSnapshot(input);
+
+		expect(snapshot.assemblerContext).toBeNull();
+	});
+
+	test("captures budget breakdown with correct accounting", () => {
+		const model = makeModel({ contextWindow: 200_000 });
+		const systemPrompt = "A".repeat(400); // ~100 tokens
+		const tools = [makeTool("tool1")];
+		const messages: AgentMessage[] = [makeUser("Hello")];
+		const packet = makePacket({ usage: { consumedTokens: 500, consumedLatencyMs: 50 } });
+
+		const input = makeInput({
+			model,
+			systemPrompt,
+			tools,
+			finalMessages: messages,
+			assemblerPacket: packet,
+		});
+		const snapshot = captureEffectivePromptSnapshot(input);
+
+		expect(snapshot.budget).not.toBeNull();
+		expect(snapshot.budget!.contextWindow).toBe(200_000);
+		expect(snapshot.budget!.systemPromptTokens).toBe(Math.ceil(systemPrompt.length / 4));
+		expect(snapshot.budget!.assembledContextTokens).toBe(500);
+		expect(snapshot.budget!.messageTokens).toBeGreaterThan(0);
+
+		// Headroom = contextWindow - sysPrompt - tools - messages - assembled
+		const expectedHeadroom =
+			200_000 -
+			snapshot.budget!.systemPromptTokens -
+			snapshot.budget!.toolDefinitionTokens -
+			snapshot.budget!.messageTokens -
+			500;
+		expect(snapshot.budget!.headroom).toBe(expectedHeadroom);
+	});
+
+	test("headroom is never negative", () => {
+		const model = makeModel({ contextWindow: 10 }); // Tiny context window
+		const systemPrompt = "A".repeat(1000); // Way more than 10 tokens
+
+		const input = makeInput({ model, systemPrompt });
+		const snapshot = captureEffectivePromptSnapshot(input);
+
+		expect(snapshot.budget!.headroom).toBeGreaterThanOrEqual(0);
+	});
+
+	test("budget is null when model is undefined", () => {
+		const input = makeInput({ model: undefined });
+		const snapshot = captureEffectivePromptSnapshot(input);
+
+		expect(snapshot.budget).toBeNull();
+	});
+
+	test("snapshot from assembler mode includes all fields", () => {
+		const metadata = makeTransformMetadata({
+			totalTurns: 10,
+			keptCount: 3,
+			stubbedCount: 5,
+			droppedCount: 2,
+			tokensBefore: 50_000,
+			tokensAfter: 20_000,
+		});
+		const packet = makePacket({
+			usage: { consumedTokens: 3000, consumedLatencyMs: 200 },
+			fragments: [
+				{
+					id: "f1",
+					tier: "short_term",
+					content: "code snippet",
+					score: 0.9,
+					provenance: {
+						source: "bridge:read",
+						reason: "tool_result",
+						capturedAt: "2025-01-01T00:00:00.000Z",
+						confidence: 1.0,
+					},
+				},
+				{
+					id: "f2",
+					tier: "long_term",
+					content: "context info",
+					score: 0.7,
+					provenance: {
+						source: "bridge:grep",
+						reason: "tool_result",
+						capturedAt: "2025-01-01T00:00:00.000Z",
+						confidence: 0.8,
+					},
+				},
+			],
+			dropped: [{ id: "f3", reason: "token_budget" }],
+		});
+		const budget = {
+			maxTokens: 150_000,
+			maxLatencyMs: 2000,
+			reservedTokens: { objective: 0, codeContext: 0, executionState: 0 },
+		};
+
+		const input = makeInput({
+			transformMetadata: metadata,
+			assemblerPacket: packet,
+			assemblerBudget: budget,
+		});
+		const snapshot = captureEffectivePromptSnapshot(input);
+
+		// Verify all sections are populated
+		expect(snapshot.systemPrompt.fingerprint.length).toBeGreaterThan(0);
+		expect(snapshot.tools.names.length).toBeGreaterThan(0);
+		expect(snapshot.messages.final.length).toBeGreaterThan(0);
+		expect(snapshot.messages.transformMetadata).not.toBeNull();
+		expect(snapshot.assemblerContext).not.toBeNull();
+		expect(snapshot.budget).not.toBeNull();
+
+		// Verify transform metadata is the actual structured data
+		expect(snapshot.messages.transformMetadata!.droppedCount).toBe(2);
+		expect(snapshot.messages.transformMetadata!.stubbedCount).toBe(5);
+
+		// Verify assembler packet is faithfully recorded
+		expect(snapshot.assemblerContext!.packet.fragments.length).toBe(2);
+		expect(snapshot.assemblerContext!.packet.dropped.length).toBe(1);
+		expect(snapshot.assemblerContext!.packet.usage.consumedTokens).toBe(3000);
+	});
+
+	test("snapshot from non-assembler mode has null assembler fields", () => {
+		const input = makeInput({
+			transformMetadata: null,
+			assemblerPacket: null,
+			assemblerBudget: null,
+		});
+		const snapshot = captureEffectivePromptSnapshot(input);
+
+		expect(snapshot.messages.transformMetadata).toBeNull();
+		expect(snapshot.assemblerContext).toBeNull();
+		// Budget should still be present (derived from model)
+		expect(snapshot.budget).not.toBeNull();
+	});
+
+	test("capturedAt is a valid ISO 8601 timestamp", () => {
+		const snapshot = captureEffectivePromptSnapshot(makeInput());
+		const parsed = new Date(snapshot.capturedAt);
+		expect(parsed.toISOString()).toBe(snapshot.capturedAt);
+	});
+
+	test("empty tools list produces zero token estimate", () => {
+		const input = makeInput({ tools: [] });
+		const snapshot = captureEffectivePromptSnapshot(input);
+
+		expect(snapshot.tools.names).toEqual([]);
+		expect(snapshot.tools.totalDefinitionTokenEstimate).toBe(0);
+	});
+
+	test("empty messages list produces zero token estimate", () => {
+		const input = makeInput({ finalMessages: [] });
+		const snapshot = captureEffectivePromptSnapshot(input);
+
+		expect(snapshot.messages.final).toEqual([]);
+		expect(snapshot.messages.tokenEstimate).toBe(0);
+	});
+
+	test("snapshot accurately reflects message bounding changes", () => {
+		// Simulate a scenario where bounding dropped messages
+		const fullMessages: AgentMessage[] = Array.from({ length: 20 }, (_, i) => makeUser(`Message ${i}`));
+		const boundedMessages = fullMessages.slice(15); // Only last 5 kept
+
+		const metadata = makeTransformMetadata({
+			totalTurns: 20,
+			keptCount: 5,
+			droppedCount: 15,
+			tokensBefore: 10_000,
+			tokensAfter: 2_500,
+		});
+
+		const snap = captureEffectivePromptSnapshot(
+			makeInput({
+				finalMessages: boundedMessages,
+				transformMetadata: metadata,
+			}),
+		);
+
+		expect(snap.messages.final.length).toBe(5);
+		expect(snap.messages.transformMetadata!.droppedCount).toBe(15);
+		expect(snap.messages.transformMetadata!.keptCount).toBe(5);
+		expect(snap.messages.transformMetadata!.tokensBefore).toBe(10_000);
+		expect(snap.messages.transformMetadata!.tokensAfter).toBe(2_500);
+	});
+});


### PR DESCRIPTION
Closes #26

## Summary

Introduces `EffectivePromptSnapshot` - a canonical runtime snapshot of the effective prompt composition captured inside the real composition path (`sdk.ts` `transformContext`) immediately before the model call.

### What is captured per turn

| Section | Contents |
|---------|----------|
| System prompt | Stable fingerprint (xxHash64) + token estimate |
| Tools | Ordered name list + total definition token estimate |
| Messages | Final post-transform bounded message array + token estimate |
| Transform metadata | Structured per-turn decisions from #25 (kept/stubbed/dropped counts, token accounting) |
| Assembler context | Full WorkingContextPacketV1 (fragments, drops, usage) when assembler is active |
| Budget | Context window, system prompt tokens, tool tokens, message tokens, assembled context tokens, headroom |

### Capture path

- Assembler mode: Snapshot captured inside assemblerTransform with full transform metadata and assembled context packet
- Non-assembler mode: Minimal snapshot captured in the outer transform wrapper with system prompt, tools, and passthrough messages
- All modes: transformContext now always returns a function (previously could be undefined) to ensure snapshot capture

### Access

```typescript
session.lastPromptSnapshot // EffectivePromptSnapshot | null
```

### Files

| File | Change |
|------|--------|
| src/context/effective-prompt-snapshot.ts | New - type definitions + capture function |
| src/sdk.ts | Modified - snapshot capture in transformContext, TransformMetadata retention |
| src/session/agent-session.ts | Modified - lastPromptSnapshot getter |
| test/effective-prompt-snapshot.test.ts | New - 24 tests covering all snapshot sections |

### Verification

- tsgo type check passes with zero errors
- 24 new tests pass
- 37 existing message-transform tests unaffected


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added access to per-turn effective prompt snapshots (prompt, tools, messages, token estimates and headroom) via the AgentSession API so callers can inspect what was sent to the model after message composition.
  * Snapshots are captured automatically during message assembly for both assembler and non-assembler flows.

* **Tests**
  * Comprehensive unit tests added to validate snapshot contents, fingerprinting, token estimates, timestamps, and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->