### PR TITLE
fix: formatting issues from #30 merge

### DIFF
--- a/packages/coding-agent/src/session/compaction/compaction.ts
+++ b/packages/coding-agent/src/session/compaction/compaction.ts
@@ -181,7 +181,6 @@ export function getLastAssistantUsage(entries: SessionEntry[]): Usage | undefine
 	return undefined;
 }
 
-
 // ============================================================================
 // Cut point detection
 // ============================================================================

--- a/packages/coding-agent/test/agent-session-context-promotion.test.ts
+++ b/packages/coding-agent/test/agent-session-context-promotion.test.ts
@@ -193,7 +193,7 @@ describe("AgentSession context promotion", () => {
 		session = new AgentSession({
 			agent,
 			sessionManager: SessionManager.inMemory(),
-		settings: Settings.isolated(),
+			settings: Settings.isolated(),
 			modelRegistry,
 		});
 
@@ -230,7 +230,7 @@ describe("AgentSession context promotion", () => {
 		session = new AgentSession({
 			agent,
 			sessionManager: SessionManager.inMemory(),
-		settings: Settings.isolated(),
+			settings: Settings.isolated(),
 			modelRegistry,
 		});
 
@@ -265,7 +265,7 @@ describe("AgentSession context promotion", () => {
 		session = new AgentSession({
 			agent,
 			sessionManager: SessionManager.inMemory(),
-		settings: Settings.isolated(),
+			settings: Settings.isolated(),
 			modelRegistry,
 		});
 
@@ -306,7 +306,7 @@ describe("AgentSession context promotion", () => {
 		session = new AgentSession({
 			agent,
 			sessionManager: SessionManager.inMemory(),
-		settings: Settings.isolated(),
+			settings: Settings.isolated(),
 			modelRegistry,
 		});
 

--- a/packages/coding-agent/test/context-manager.test.ts
+++ b/packages/coding-agent/test/context-manager.test.ts
@@ -85,7 +85,6 @@ describe("context-manager", () => {
 			expect(() => validateContextManagerConfig(settings)).toThrow(/memories\.enabled/);
 		});
 
-
 		it("accepts assembler mode when legacy subsystems are disabled", () => {
 			const settings = Settings.isolated({
 				"contextManager.mode": "assembler",


### PR DESCRIPTION
Cherry-pick of formatting fixes that were on issue/30 but not included in the merge commit for #30.

Fixes:
- `agent-session-context-promotion.test.ts`: Fix indentation of `settings:` property (2 tabs -> 3 tabs) in 4 test cases
- `context-manager.test.ts`: Remove extra blank line between test cases
- `compaction.ts`: Remove extra blank line before Cut point detection section

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated code formatting and whitespace consistency across internal files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->