### PR TITLE
Split CI fast-path from native/check work and remove duplicate native builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # ── Rust static analysis ──────────────────────────────────────────────
+  # Owns: cargo fmt, clippy, cargo check. No JS, no native build.
   rust:
     runs-on: namespace-profile-default
     env:
@@ -29,6 +31,9 @@ jobs:
       - name: Check
         run: cargo check --workspace
 
+  # ── Native addon build matrix ────────────────────────────────────────
+  # Owns: compiling Rust → .node for each platform/arch/variant.
+  # Produces upload artifacts consumed by test and contracts jobs.
   native:
     strategy:
       fail-fast: false
@@ -77,11 +82,34 @@ jobs:
           path: packages/natives/native/pi_natives.${{ matrix.platform }}-${{ matrix.arch }}*.node
           if-no-files-found: error
 
-
-  test:
+  # ── TypeScript static analysis ──────────────────────────────────────
+  # Owns: biome lint/format checks and tsgo type checking.
+  # No native build needed — type definitions live in .ts source files.
+  check:
     runs-on: namespace-profile-default
-    env:
-      RUSTFLAGS: -C target-cpu=x86-64-v3
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3"
+      - name: Cache bun dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: bun-${{ runner.os }}-${{ hashFiles('**/bun.lock') }}
+      - name: Install system deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev
+      - run: bun install --frozen-lockfile
+      - run: bun check:ts
+
+  # ── Test suites ──────────────────────────────────────────────────────
+  # Owns: bun test (all workspaces) and CLI smoke tests.
+  # Downloads pre-built native artifacts — does NOT rebuild them.
+  test:
+    needs: [native]
+    runs-on: namespace-profile-default
     steps:
       - uses: actions/checkout@v4
         with:
@@ -101,8 +129,11 @@ jobs:
           sudo ln -s $(which fdfind) /usr/local/bin/fd
           sudo ln -sf /usr/bin/convert /usr/local/bin/magick
       - run: bun install --frozen-lockfile
-      - run: bun --cwd=packages/natives run build:native
-      - run: bun run check
+      - name: Download native addon
+        uses: actions/download-artifact@v4
+        with:
+          name: pi-natives-linux-x64
+          path: packages/natives/native/
       - run: bun run test
       - name: CLI smoke test
         run: |
@@ -110,10 +141,12 @@ jobs:
           bun packages/coding-agent/src/cli.ts --help
           bun packages/coding-agent/src/cli.ts stats --help
 
+  # ── Contract tests ───────────────────────────────────────────────────
+  # Owns: RPC compatibility and memory contract suites.
+  # Downloads pre-built native artifacts — does NOT rebuild them.
   contracts:
+    needs: [native]
     runs-on: namespace-profile-default
-    env:
-      RUSTFLAGS: -C target-cpu=x86-64-v3
     steps:
       - uses: actions/checkout@v4
         with:
@@ -133,13 +166,19 @@ jobs:
           sudo ln -s $(which fdfind) /usr/local/bin/fd
           sudo ln -sf /usr/bin/convert /usr/local/bin/magick
       - run: bun install --frozen-lockfile
-      - run: bun --cwd=packages/natives run build:native
+      - name: Download native addon
+        uses: actions/download-artifact@v4
+        with:
+          name: pi-natives-linux-x64
+          path: packages/natives/native/
       - name: Run contract suites
         run: |
           bun --cwd=packages/coding-agent test test/rpc-compatibility-contract.test.ts
           bun --cwd=packages/coding-agent test test/memory-contract.test.ts
 
 
+  # ── Install method smoke tests ────────────────────────────────────────
+  # Owns: verifying that published install paths work end-to-end.
   install_methods:
     runs-on: namespace-profile-default
     env:

--- a/packages/natives/package.json
+++ b/packages/natives/package.json
@@ -34,7 +34,7 @@
 		"embed:native": "bun scripts/embed-native.ts",
 		"check": "biome check . && tsgo -p tsconfig.json",
 		"fix": "biome check --write --unsafe .",
-		"test": "bun run build:native && bun test",
+		"test": "bun test",
 		"bench": "bun bench/grep.ts"
 	},
 	"dependencies": {


### PR DESCRIPTION
Closes #32

## Summary

Restructures CI so each workflow job owns a single responsibility, removing duplicated native-build and static-check work from the test lane.

### Before
- `test` job: installs system deps, builds natives (~4m18s), runs `bun run check` (~1m20s), runs `bun run test`, CLI smoke tests
- `contracts` job: installs system deps, builds natives, runs contract suites
- Native build duplicated in 3 places (native job, test job, contracts job)
- `packages/natives` test script also rebuilds natives

### After

| Job | Responsibility | Dependencies |
|-----|---------------|-------------|
| `rust` | Rust static analysis (fmt, clippy, check) | none |
| `native` | Build native addons, upload artifacts | none |
| `check` (NEW) | TypeScript static analysis (biome + tsgo) | none |
| `test` | bun test + CLI smoke tests | `native` (downloads artifacts) |
| `contracts` | Contract test suites | `native` (downloads artifacts) |
| `install_methods` | Install method smoke tests | none |

### Changes
- **Added `check` job**: Runs `bun check:ts` (biome + tsgo type checking). No native build needed — type definitions live in .ts source files.
- **Restructured `test` job**: Downloads pre-built native artifacts from the `native` job via `actions/download-artifact`. Removed `bun run check` (covered by `check` + `rust` jobs). Removed native rebuild.
- **Restructured `contracts` job**: Same artifact download pattern. Removed native rebuild.
- **Fixed `packages/natives` test script**: Changed from `bun run build:native && bun test` to `bun test`. Native build is a prerequisite responsibility, not part of testing.
- **Added job comments**: Each job has a header comment documenting its responsibility to prevent future overlap.

### Wall-clock impact
- `test` and `contracts` jobs save ~4m18s each (no native rebuild)
- `check` job runs in parallel with everything, ~1m20s
- `test`/`contracts` now wait for `native` to finish before starting, but the download is near-instant vs rebuilding

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced continuous integration pipeline with Rust and TypeScript static analysis
  * Added native builds for multiple platforms (Linux x64, macOS ARM64)
  * Improved test workflows including contract verification and install method validation
  * Streamlined native test execution process

<!-- end of auto-generated comment: release notes by coderabbit.ai -->