### PR TITLE
Add context model awareness to system prompt

### DIFF
--- a/packages/coding-agent/src/prompts/system/system-prompt.md
+++ b/packages/coding-agent/src/prompts/system/system-prompt.md
@@ -206,6 +206,16 @@ You **MUST NOT** open a file hoping. Hope is not a strategy.
 {{#has tools "read"}}- Known location → `read` with offset/limit, not whole file{{/has}}
 {{/ifAny}}
 
+# Context Model
+
+You are a memory-augmented collaborator with layered context:
+1. **Prepopulated** (automatic each turn): context files, tool descriptions, skills, rules. Always present — no action needed.
+2. **Project recall** (cross-session): project-scoped session history that persists across sessions within this working directory. Use `recall` to search past work, decisions, and file reads.
+3. **Knowledge servers** (cross-project, via MCP): connected servers provide code intelligence, external knowledge, and business context. Server-specific instructions appear separately below.
+4. **Code structure tools**: LSP for semantic questions (definitions, references, types), `ast_grep` for structural patterns, `grep` for text search.
+
+**Retrieval strategy:** project history and past decisions → `recall`. Cross-project or domain knowledge → MCP server tools. Code structure (definitions, callers, types) → LSP. Syntax patterns → `ast_grep`. Text patterns → `grep`.
+
 {{SECTION_SEPERATOR "Rules"}}
 
 # Contract


### PR DESCRIPTION
Closes #55

## Summary

Adds a concise "Context Model" section to `system-prompt.md` that gives the LLM an organizing mental model for its layered context architecture:

1. **Prepopulated** (automatic each turn): context files, tool descriptions, skills, rules
2. **Project recall** (cross-session): project-scoped session history persisting across sessions
3. **Knowledge servers** (cross-project, via MCP): connected servers for code intelligence, external knowledge, business context
4. **Code structure tools**: LSP, ast_grep, grep for structural/semantic code questions

Includes a retrieval strategy summary mapping information needs to the right context source.

**Placement:** after Tools, before Rules (per issue spec)
**Size:** 9 lines of prompt text (under the 20-line budget)
**No duplication:** does not repeat MCP server instructions or individual tool descriptions -- provides the organizing frame only

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced the coding agent's system prompt with improved context model specifications, detailed layered context retrieval strategy, and expanded design rules for optimized agent operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->