### PR TITLE
Surface assembly metadata to the LLM in-context

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Surface assembly metadata to the LLM as a compact developer message each turn, including turn composition (kept/stubbed/dropped counts with affected ranges) and budget usage with headroom ([#58](https://github.com/open-horizon-labs/oh-omp/issues/58))
+
 ## [13.9.10] - 2026-03-08
 ### Added
 

--- a/packages/coding-agent/src/context/assembly-summary.ts
+++ b/packages/coding-agent/src/context/assembly-summary.ts
@@ -1,0 +1,80 @@
+/**
+ * Compact assembly summary for LLM in-context consumption.
+ *
+ * Derives a concise one-line dashboard from an EffectivePromptSnapshot so the
+ * LLM can make informed decisions about its context window state: what was
+ * kept, what was stubbed/dropped, and how much headroom remains.
+ *
+ * Injected as a developer message before the conversation — not as user
+ * content — so it functions as system-level metadata the LLM can reference
+ * but doesn't need to respond to directly.
+ */
+
+import { formatNumber } from "@oh-my-pi/pi-utils";
+import type { TurnDecision } from "./assembler/message-transform";
+import type { EffectivePromptSnapshot } from "./effective-prompt-snapshot";
+
+/**
+ * Format a compact assembly summary from a prompt snapshot.
+ *
+ * Returns null when there is no meaningful assembly metadata to surface
+ * (no transform metadata and no budget data).
+ *
+ * Format (representative):
+ * ```
+ * [Assembly: 45 turns, 8 kept, 12 stubbed (turns 3-14), 25 dropped | Budget: 182K/200K tokens, 18K headroom]
+ * ```
+ */
+export function formatAssemblySummary(snapshot: EffectivePromptSnapshot): string | null {
+	const meta = snapshot.messages.transformMetadata;
+	const budget = snapshot.budget;
+
+	// Nothing to surface without at least one of these.
+	if (!meta && !budget) return null;
+
+	const parts: string[] = [];
+
+	// Turn composition segment.
+	if (meta) {
+		const turnParts: string[] = [`${meta.totalTurns} turns`];
+		if (meta.keptCount > 0) turnParts.push(`${meta.keptCount} kept`);
+		if (meta.stubbedCount > 0) {
+			const range = describeStubbedRange(meta.decisions);
+			turnParts.push(range ? `${meta.stubbedCount} stubbed (${range})` : `${meta.stubbedCount} stubbed`);
+		}
+		if (meta.droppedCount > 0) turnParts.push(`${meta.droppedCount} dropped`);
+		parts.push(turnParts.join(", "));
+	}
+
+	// Budget segment.
+	if (budget && budget.contextWindow > 0) {
+		const used = budget.contextWindow - budget.headroom;
+		parts.push(
+			`Budget: ${formatNumber(used)}/${formatNumber(budget.contextWindow)} tokens, ${formatNumber(budget.headroom)} headroom`,
+		);
+	}
+
+	if (parts.length === 0) return null;
+
+	return `[Assembly: ${parts.join(" | ")}]`;
+}
+
+/**
+ * Describe the turn range affected by stubbing as a compact string.
+ *
+ * Returns e.g. "turns 3-14", "turn 5", or null if no turns were stubbed.
+ */
+function describeStubbedRange(decisions: TurnDecision[]): string | null {
+	let min = Number.POSITIVE_INFINITY;
+	let max = Number.NEGATIVE_INFINITY;
+
+	for (const d of decisions) {
+		if (d.action !== "stubbed") continue;
+		if (d.turnIndex < min) min = d.turnIndex;
+		if (d.turnIndex > max) max = d.turnIndex;
+	}
+
+	if (min === Number.POSITIVE_INFINITY) return null;
+	if (min === max) return `turn ${min}`;
+	return `turns ${min}-${max}`;
+}

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -33,6 +33,7 @@ import {
 	type TransformMetadata,
 	transformMessages,
 } from "./context/assembler";
+import { formatAssemblySummary } from "./context/assembly-summary";
 import { ToolResultBridge } from "./context/bridge";
 import { captureEffectivePromptSnapshot, type EffectivePromptSnapshot } from "./context/effective-prompt-snapshot";
 import { extractPaths } from "./context/extract-paths";
@@ -1481,6 +1482,20 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 				assemblerPacket: null,
 				assemblerBudget: budget ?? null,
 			});
+
+			// Step 6: Inject assembly summary as developer message.
+			const summary = formatAssemblySummary(lastPromptSnapshot);
+			if (summary) {
+				return [
+					{
+						role: "developer" as const,
+						content: summary,
+						attribution: "agent" as const,
+						timestamp: Date.now(),
+					} satisfies AgentMessage,
+					...finalMessages,
+				];
+			}
 
 			return finalMessages;
 		};

--- a/packages/coding-agent/test/assembly-summary.test.ts
+++ b/packages/coding-agent/test/assembly-summary.test.ts
@@ -1,0 +1,206 @@
+import { describe, expect, test } from "bun:test";
+import type { TransformMetadata, TurnDecision } from "@oh-my-pi/pi-coding-agent/context/assembler";
+import { formatAssemblySummary } from "@oh-my-pi/pi-coding-agent/context/assembly-summary";
+import type { EffectivePromptSnapshot } from "@oh-my-pi/pi-coding-agent/context/effective-prompt-snapshot";
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Snapshot factory
+// ═══════════════════════════════════════════════════════════════════════════
+
+function makeSnapshot(overrides: {
+	meta?: TransformMetadata | null;
+	budget?: EffectivePromptSnapshot["budget"];
+}): EffectivePromptSnapshot {
+	return {
+		turnId: "turn-1",
+		capturedAt: new Date().toISOString(),
+		model: { provider: "anthropic", id: "claude-sonnet-4-20250514", contextWindow: 200_000 },
+		systemPrompt: { fingerprint: "abc123", tokenEstimate: 5_000 },
+		tools: { names: ["read", "write"], totalDefinitionTokenEstimate: 3_000 },
+		messages: {
+			final: [],
+			tokenEstimate: 50_000,
+			transformMetadata: overrides.meta !== undefined ? overrides.meta : null,
+		},
+		assemblerContext: null,
+		budget: overrides.budget !== undefined ? overrides.budget : null,
+	};
+}
+
+function makeDecision(turnIndex: number, action: TurnDecision["action"], reason: TurnDecision["reason"]): TurnDecision {
+	return {
+		turnIndex,
+		action,
+		reason,
+		messageCount: 2,
+		hasToolResults: action === "stubbed",
+		tokensBefore: 1000,
+		tokensAfter: action === "dropped" ? 0 : action === "stubbed" ? 200 : 1000,
+	};
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Tests
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe("formatAssemblySummary", () => {
+	test("returns null when no metadata and no budget", () => {
+		const snapshot = makeSnapshot({ meta: null, budget: null });
+		expect(formatAssemblySummary(snapshot)).toBeNull();
+	});
+
+	test("includes turn composition with kept/stubbed/dropped counts", () => {
+		const meta: TransformMetadata = {
+			decisions: [
+				makeDecision(0, "dropped", "budget-exceeded"),
+				makeDecision(1, "dropped", "budget-exceeded"),
+				makeDecision(2, "stubbed", "beyond-hot-window"),
+				makeDecision(3, "stubbed", "beyond-hot-window"),
+				makeDecision(4, "stubbed", "beyond-hot-window"),
+				makeDecision(5, "kept", "hot-window"),
+				makeDecision(6, "kept", "hot-window"),
+				makeDecision(7, "kept", "hot-window"),
+			],
+			totalTurns: 8,
+			keptCount: 3,
+			stubbedCount: 3,
+			droppedCount: 2,
+			tokensBefore: 8000,
+			tokensAfter: 4600,
+		};
+		const result = formatAssemblySummary(makeSnapshot({ meta }));
+		expect(result).toContain("8 turns");
+		expect(result).toContain("3 kept");
+		expect(result).toContain("3 stubbed (turns 2-4)");
+		expect(result).toContain("2 dropped");
+	});
+
+	test("includes budget usage and headroom", () => {
+		const budget: EffectivePromptSnapshot["budget"] = {
+			contextWindow: 200_000,
+			systemPromptTokens: 5_000,
+			toolDefinitionTokens: 3_000,
+			messageTokens: 50_000,
+			assembledContextTokens: 0,
+			headroom: 142_000,
+		};
+		const result = formatAssemblySummary(makeSnapshot({ budget }));
+		expect(result).toContain("Budget:");
+		expect(result).toContain("58K/200K tokens");
+		expect(result).toContain("142K headroom");
+	});
+
+	test("combines turns and budget with pipe separator", () => {
+		const meta: TransformMetadata = {
+			decisions: [makeDecision(0, "kept", "hot-window")],
+			totalTurns: 1,
+			keptCount: 1,
+			stubbedCount: 0,
+			droppedCount: 0,
+			tokensBefore: 1000,
+			tokensAfter: 1000,
+		};
+		const budget: EffectivePromptSnapshot["budget"] = {
+			contextWindow: 200_000,
+			systemPromptTokens: 5_000,
+			toolDefinitionTokens: 3_000,
+			messageTokens: 50_000,
+			assembledContextTokens: 0,
+			headroom: 142_000,
+		};
+		const result = formatAssemblySummary(makeSnapshot({ meta, budget }))!;
+		expect(result).toStartWith("[Assembly: ");
+		expect(result).toEndWith("]");
+		expect(result).toContain(" | Budget:");
+	});
+
+	test("shows single stubbed turn without range", () => {
+		const meta: TransformMetadata = {
+			decisions: [makeDecision(0, "stubbed", "beyond-hot-window"), makeDecision(1, "kept", "hot-window")],
+			totalTurns: 2,
+			keptCount: 1,
+			stubbedCount: 1,
+			droppedCount: 0,
+			tokensBefore: 2000,
+			tokensAfter: 1200,
+		};
+		const result = formatAssemblySummary(makeSnapshot({ meta }))!;
+		expect(result).toContain("1 stubbed (turn 0)");
+	});
+
+	test("omits stubbed clause when zero stubbed", () => {
+		const meta: TransformMetadata = {
+			decisions: [makeDecision(0, "kept", "hot-window"), makeDecision(1, "kept", "hot-window")],
+			totalTurns: 2,
+			keptCount: 2,
+			stubbedCount: 0,
+			droppedCount: 0,
+			tokensBefore: 2000,
+			tokensAfter: 2000,
+		};
+		const result = formatAssemblySummary(makeSnapshot({ meta }))!;
+		expect(result).not.toContain("stubbed");
+	});
+
+	test("omits dropped clause when zero dropped", () => {
+		const meta: TransformMetadata = {
+			decisions: [makeDecision(0, "kept", "hot-window")],
+			totalTurns: 1,
+			keptCount: 1,
+			stubbedCount: 0,
+			droppedCount: 0,
+			tokensBefore: 1000,
+			tokensAfter: 1000,
+		};
+		const result = formatAssemblySummary(makeSnapshot({ meta }))!;
+		expect(result).not.toContain("dropped");
+	});
+
+	test("budget-only snapshot still produces summary", () => {
+		const budget: EffectivePromptSnapshot["budget"] = {
+			contextWindow: 128_000,
+			systemPromptTokens: 4_000,
+			toolDefinitionTokens: 2_000,
+			messageTokens: 100_000,
+			assembledContextTokens: 5_000,
+			headroom: 17_000,
+		};
+		const result = formatAssemblySummary(makeSnapshot({ meta: null, budget }))!;
+		expect(result).toStartWith("[Assembly: Budget:");
+		expect(result).toContain("111K/128K tokens");
+		expect(result).toContain("17K headroom");
+	});
+
+	test("returns null for zero context window budget", () => {
+		const budget: EffectivePromptSnapshot["budget"] = {
+			contextWindow: 0,
+			systemPromptTokens: 0,
+			toolDefinitionTokens: 0,
+			messageTokens: 0,
+			assembledContextTokens: 0,
+			headroom: 0,
+		};
+		const result = formatAssemblySummary(makeSnapshot({ meta: null, budget }));
+		expect(result).toBeNull();
+	});
+
+	test("non-contiguous stubbed turns show full range", () => {
+		const meta: TransformMetadata = {
+			decisions: [
+				makeDecision(0, "dropped", "budget-exceeded"),
+				makeDecision(1, "stubbed", "beyond-hot-window"),
+				makeDecision(2, "kept", "no-tool-results"),
+				makeDecision(3, "stubbed", "beyond-hot-window"),
+				makeDecision(4, "kept", "hot-window"),
+			],
+			totalTurns: 5,
+			keptCount: 2,
+			stubbedCount: 2,
+			droppedCount: 1,
+			tokensBefore: 5000,
+			tokensAfter: 2400,
+		};
+		const result = formatAssemblySummary(makeSnapshot({ meta }))!;
+		expect(result).toContain("2 stubbed (turns 1-3)");
+	});
+});


### PR DESCRIPTION
Closes #58

## Summary

Injects a compact assembly summary as a developer message each turn so the LLM can make informed decisions about its context window state.

**New file:** `packages/coding-agent/src/context/assembly-summary.ts`
- `formatAssemblySummary(snapshot)` — pure function that takes an `EffectivePromptSnapshot` and produces a one-line dashboard, or null when there is nothing to surface
- Includes turn composition (kept/stubbed/dropped with affected turn range) and budget usage with headroom
- Uses existing `formatNumber` from pi-utils for compact token display (e.g. "182K")

**Modified:** `packages/coding-agent/src/sdk.ts`
- After capturing the prompt snapshot in `assemblerTransform`, generates the summary
- Prepends it as a `developer` message (system-level, not user content) before the conversation

**Format example:**

    [Assembly: 45 turns, 8 kept, 12 stubbed (turns 3-14), 25 dropped | Budget: 182K/200K tokens, 18K headroom]

**Tests:** `packages/coding-agent/test/assembly-summary.test.ts` — 10 tests covering:
- Null return when no metadata/budget
- Turn composition with kept/stubbed/dropped counts
- Stubbed turn range (single turn, range, non-contiguous)
- Budget usage and headroom formatting
- Combined turns + budget with pipe separator
- Edge cases (zero context window, budget-only snapshots)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Assembly metadata is now surfaced to the LLM as a developer message each turn, including turn composition (kept/stubbed/dropped counts with affected ranges) and budget usage metrics with headroom.

* **Documentation**
  * Updated changelog documenting new assembly metadata visibility.

* **Tests**
  * Added comprehensive test coverage for assembly metadata formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->