### PR TITLE
Add source provenance tags to assembled context

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Surface assembly metadata to the LLM as a compact developer message each turn, including turn composition (kept/stubbed/dropped counts with affected ranges) and budget usage with headroom ([#58](https://github.com/open-horizon-labs/oh-omp/issues/58))
+- Add source provenance tags to assembled context: MCP tool results are tagged `mcp:serverName`, builtin tools as `tool:name`, and recall results include session age signals ([#59](https://github.com/open-horizon-labs/oh-omp/issues/59))
 
 ## [13.9.10] - 2026-03-08
 ### Added

--- a/packages/coding-agent/src/context/assembler/message-transform.ts
+++ b/packages/coding-agent/src/context/assembler/message-transform.ts
@@ -17,12 +17,34 @@
 
 import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
 import type { TextContent, ToolResultMessage } from "@oh-my-pi/pi-ai";
+import { parseMCPToolName } from "../../mcp/tool-bridge";
 import type { MemoryAssemblyBudget } from "../memory-contract";
 import type { BudgetDerivationInput } from "./types";
 
 // ═══════════════════════════════════════════════════════════════════════════
 // Token estimation & budget derivation
 // ═══════════════════════════════════════════════════════════════════════════
+
+/**
+ * Extract source provenance tags from messages in a turn.
+ * For tool_result messages, derives the source from toolName.
+ * MCP tools get "mcp:serverName", builtins get "tool:toolName".
+ */
+function extractSourceTags(messages: AgentMessage[]): string[] {
+	const tags = new Set<string>();
+	for (const msg of messages) {
+		if (msg.role !== "toolResult") continue;
+		const toolName = (msg as { toolName?: string }).toolName;
+		if (!toolName) continue;
+		const mcpParts = parseMCPToolName(toolName);
+		if (mcpParts) {
+			tags.add(`mcp:${mcpParts.serverName}`);
+		} else {
+			tags.add(`tool:${toolName}`);
+		}
+	}
+	return [...tags];
+}
 
 function estimateTokensFromCharCount(chars: number): number {
 	return Math.ceil(chars / 4);
@@ -94,6 +116,12 @@ export const DEFAULT_HOT_WINDOW_TURNS = 3;
 /** Stub text injected into tool_result messages beyond the hot window. */
 export const TOOL_RESULT_STUB_TEXT = "[Content available in assembled context]";
 
+/** Format stub text with source provenance tags. */
+export function formatStubText(sourceTags?: string[]): string {
+	if (!sourceTags || sourceTags.length === 0) return TOOL_RESULT_STUB_TEXT;
+	return `[source: ${sourceTags.join(", ")} | Content replaced \u2014 available via re-execution]`;
+}
+
 export interface MessageTransformOptions {
 	/** Number of recent turns to keep verbatim (default: {@link DEFAULT_HOT_WINDOW_TURNS}). */
 	hotWindowTurns?: number;
@@ -154,6 +182,9 @@ export interface TurnDecision {
 
 	/** Estimated tokens after transformation (0 if dropped). */
 	tokensAfter: number;
+
+	/** Source provenance tags for tools in this turn (e.g. "tool:grep", "mcp:rna-server"). Empty for non-tool turns. */
+	sourceTags: string[];
 }
 
 /**
@@ -294,13 +325,14 @@ export function segmentIntoTurns(messages: AgentMessage[]): Turn[] {
  * Returns a new array of messages with tool_result content replaced.
  * Assistant messages and other message types are passed through unchanged.
  */
-function replaceToolResultContent(turn: Turn): Turn {
+function replaceToolResultContent(turn: Turn, sourceTags?: string[]): Turn {
 	if (!turn.hasToolResults) return turn;
 
+	const stubText = formatStubText(sourceTags);
 	const replaced = turn.messages.map((msg): AgentMessage => {
 		if (msg.role !== "toolResult") return msg;
 
-		const stubContent: TextContent[] = [{ type: "text", text: TOOL_RESULT_STUB_TEXT }];
+		const stubContent: TextContent[] = [{ type: "text", text: stubText }];
 		return {
 			...msg,
 			content: stubContent,
@@ -406,7 +438,8 @@ export function transformMessages(messages: AgentMessage[], options: MessageTran
 
 	const transformedTurns = originalTurns.map((turn, idx) => {
 		if (idx >= hotWindowStart) return turn; // hot window: keep verbatim
-		return replaceToolResultContent(turn);
+		const tags = extractSourceTags(turn.messages);
+		return replaceToolResultContent(turn, tags);
 	});
 
 	// Pre-compute transformed token costs (only differs from original for stubbed turns)
@@ -432,6 +465,8 @@ export function transformMessages(messages: AgentMessage[], options: MessageTran
 		const tokensBefore = originalTokens[i];
 		totalTokensBefore += tokensBefore;
 
+		const sourceTags = extractSourceTags(originalTurns[i].messages);
+
 		if (i < dropCount) {
 			// Dropped for budget
 			decisions.push({
@@ -442,6 +477,7 @@ export function transformMessages(messages: AgentMessage[], options: MessageTran
 				hasToolResults: originalTurns[i].hasToolResults,
 				tokensBefore,
 				tokensAfter: 0,
+				sourceTags,
 			});
 			droppedCount++;
 		} else if (i >= hotWindowStart) {
@@ -454,6 +490,7 @@ export function transformMessages(messages: AgentMessage[], options: MessageTran
 				hasToolResults: originalTurns[i].hasToolResults,
 				tokensBefore,
 				tokensAfter: tokensBefore,
+				sourceTags,
 			});
 			totalTokensAfter += tokensBefore;
 			keptCount++;
@@ -468,6 +505,7 @@ export function transformMessages(messages: AgentMessage[], options: MessageTran
 				hasToolResults: true,
 				tokensBefore,
 				tokensAfter,
+				sourceTags,
 			});
 			totalTokensAfter += tokensAfter;
 			stubbedCount++;
@@ -481,6 +519,7 @@ export function transformMessages(messages: AgentMessage[], options: MessageTran
 				hasToolResults: false,
 				tokensBefore,
 				tokensAfter: tokensBefore,
+				sourceTags,
 			});
 			totalTokensAfter += tokensBefore;
 			keptCount++;

--- a/packages/coding-agent/src/context/bridge/bridge.ts
+++ b/packages/coding-agent/src/context/bridge/bridge.ts
@@ -193,7 +193,7 @@ export class ToolResultBridge {
 		}
 
 		const provenance: MemoryProvenance = {
-			source: `tool:${profile.toolName}`,
+			source: profile.mcpServerName ? `mcp:${profile.mcpServerName}` : `tool:${profile.toolName}`,
 			reason: profile.isError ? "error-observation" : "result-observation",
 			capturedAt: now,
 			confidence: profile.isError ? 0.5 : 0.9,

--- a/packages/coding-agent/src/context/bridge/classify.ts
+++ b/packages/coding-agent/src/context/bridge/classify.ts
@@ -5,6 +5,7 @@
  * and invalidation rules in the bridge.
  */
 
+import { parseMCPToolName } from "../../mcp/tool-bridge";
 import type { MemoryFreshnessPolicy, MemoryLocatorRetrievalMethod, MemoryLocatorTrustLevel } from "../memory-contract";
 import { CATEGORY_FRESHNESS, type ResultProfile, type ToolResultCategory } from "./types";
 
@@ -193,7 +194,7 @@ export function classifyResult(
 	// For mutation tools, add touched paths as invalidation targets on lookup/read entries
 	// This is applied during locator generation in the bridge, not here.
 
-	return {
+	const profile: ResultProfile = {
 		toolName,
 		category,
 		trust,
@@ -203,4 +204,12 @@ export function classifyResult(
 		hasArtifact: hasArtifactReference(result),
 		isError,
 	};
+
+	// Detect MCP tools and extract server name
+	const mcpParts = parseMCPToolName(toolName);
+	if (mcpParts) {
+		return { ...profile, mcpServerName: mcpParts.serverName };
+	}
+
+	return profile;
 }

--- a/packages/coding-agent/src/context/bridge/types.ts
+++ b/packages/coding-agent/src/context/bridge/types.ts
@@ -62,6 +62,8 @@ export interface ResultProfile {
 	hasArtifact: boolean;
 	/** Whether the tool execution was an error. */
 	isError: boolean;
+	/** MCP server name if this is an MCP tool (parsed from compound name). */
+	mcpServerName?: string;
 }
 
 // ═══════════════════════════════════════════════════════════════════════════

--- a/packages/coding-agent/src/context/recall/passive-hydration.ts
+++ b/packages/coding-agent/src/context/recall/passive-hydration.ts
@@ -13,6 +13,7 @@
 
 import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
 import { logger } from "@oh-my-pi/pi-utils";
+import { parseMCPToolName } from "../../mcp/tool-bridge";
 import { embed } from "./embed";
 import { extractAssistantText, extractToolResultText, extractUserText } from "./message-text";
 import { cosineSimilarity, mmrRerank } from "./mmr";
@@ -147,7 +148,7 @@ export class CosineCache {
  *
  * Returns null when there are no results to inject.
  */
-export function formatHydratedContext(results: RecallSearchResult[]): string | null {
+export function formatHydratedContext(results: RecallSearchResult[], currentSessionId?: string): string | null {
 	if (results.length === 0) return null;
 
 	const parts: string[] = ["<recalled-context>"];
@@ -156,6 +157,17 @@ export function formatHydratedContext(results: RecallSearchResult[]): string | n
 		const attrs: string[] = [`turn="${result.turn}"`, `role="${result.role}"`];
 		if (result.tool_name) {
 			attrs.push(`tool="${result.tool_name}"`);
+			const mcpParts = parseMCPToolName(result.tool_name);
+			if (mcpParts) {
+				attrs.push(`source="mcp:${mcpParts.serverName}"`);
+			} else {
+				attrs.push(`source="tool:${result.tool_name}"`);
+			}
+		} else {
+			attrs.push(`source="${result.role}"`);
+		}
+		if (currentSessionId) {
+			attrs.push(`session="${result.session_id === currentSessionId ? "current" : "other"}"`);
 		}
 		parts.push(`<entry ${attrs.join(" ")}>`);
 		parts.push(result.text);
@@ -173,6 +185,7 @@ export function formatHydratedContext(results: RecallSearchResult[]): string | n
 export interface PassiveHydratorOptions {
 	store: RecallStore;
 	license: string;
+	sessionId?: string;
 	topK?: number;
 	mmrLambda?: number;
 	cosineThreshold?: number;
@@ -193,6 +206,7 @@ export interface HydrationResult {
 export class PassiveHydrator {
 	#store: RecallStore;
 	#license: string;
+	#sessionId: string;
 	#cache: CosineCache;
 	#topK: number;
 	#mmrLambda: number;
@@ -201,6 +215,7 @@ export class PassiveHydrator {
 	constructor(options: PassiveHydratorOptions) {
 		this.#store = options.store;
 		this.#license = options.license;
+		this.#sessionId = options.sessionId ?? "unknown";
 		this.#topK = options.topK ?? DEFAULT_TOP_K;
 		this.#mmrLambda = options.mmrLambda ?? DEFAULT_RECALL_MMR_LAMBDA;
 		this.#cache = new CosineCache(options.cosineThreshold ?? DEFAULT_COSINE_THRESHOLD);
@@ -258,7 +273,7 @@ export class PassiveHydrator {
 		// 3. Check cosine cache
 		const cacheResult = this.#cache.check(embedding);
 		if (cacheResult.hit) {
-			const text = formatHydratedContext(cacheResult.results);
+			const text = formatHydratedContext(cacheResult.results, this.#sessionId);
 			return {
 				text,
 				results: cacheResult.results,
@@ -291,7 +306,7 @@ export class PassiveHydrator {
 		this.#cache.update(embedding, topResults);
 
 		// 7. Format
-		const text = formatHydratedContext(topResults);
+		const text = formatHydratedContext(topResults, this.#sessionId);
 		const durationMs = Date.now() - start;
 
 		logger.debug("PassiveHydrator: hydration complete", {

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -1394,6 +1394,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		passiveHydrator = new PassiveHydrator({
 			store: recallStore,
 			license: memexLicense,
+			sessionId,
 		});
 		logger.debug("Recall pipeline initialized (ingest + passive hydration)");
 	}

--- a/packages/coding-agent/src/tools/recall.ts
+++ b/packages/coding-agent/src/tools/recall.ts
@@ -6,6 +6,7 @@ import { embed } from "../context/recall/embed";
 import { mmrRerank } from "../context/recall/mmr";
 import type { RecallStore } from "../context/recall/store";
 import type { MmrCandidate, RecallSearchResult } from "../context/recall/types";
+import { parseMCPToolName } from "../mcp/tool-bridge";
 import recallDescription from "../prompts/tools/recall.md" with { type: "text" };
 import type { ToolSession } from ".";
 import { shortenPath } from "./render-utils";
@@ -43,17 +44,20 @@ export class RecallTool implements AgentTool<typeof recallSchema> {
 	#store: RecallStore;
 	#license: string;
 	#cwd: string;
+	#sessionId: string;
 
-	constructor(store: RecallStore, license: string, cwd: string) {
+	constructor(store: RecallStore, license: string, cwd: string, sessionId: string) {
 		this.description = renderPromptTemplate(recallDescription);
 		this.#store = store;
 		this.#license = license;
 		this.#cwd = cwd;
+		this.#sessionId = sessionId;
 	}
 
 	static createIf(session: ToolSession): RecallTool | null {
 		if (!session.recallStore || !session.memexLicense) return null;
-		return new RecallTool(session.recallStore, session.memexLicense, session.cwd);
+		const sessionId = session.getSessionId?.() ?? "unknown";
+		return new RecallTool(session.recallStore, session.memexLicense, session.cwd, sessionId);
 	}
 
 	async execute(_toolCallId: string, params: RecallParams, _signal?: AbortSignal): Promise<AgentToolResult> {
@@ -117,7 +121,7 @@ export class RecallTool implements AgentTool<typeof recallSchema> {
 		const topResults = reranked.slice(0, limit);
 
 		// Step 6: Format results
-		const formatted = topResults.map(r => formatResult(r.data)).join("\n\n---\n\n");
+		const formatted = topResults.map(r => formatResult(r.data, this.#sessionId)).join("\n\n---\n\n");
 
 		logger.debug("Recall: returned results", {
 			query: params.query.slice(0, 80),
@@ -131,11 +135,26 @@ export class RecallTool implements AgentTool<typeof recallSchema> {
 	}
 }
 
-function formatResult(r: RecallSearchResult): string {
-	// Header: Turn N [role: tool_name] project: /path paths: x, y
+function formatResult(r: RecallSearchResult, currentSessionId: string): string {
+	// Header: Turn N [role: tool_name] source: <tag> session: <age> project: /path paths: x, y
 	let header = `Turn ${r.turn} [${r.role}`;
 	if (r.tool_name) header += `: ${r.tool_name}`;
 	header += "]";
+
+	// Source tag
+	if (r.tool_name) {
+		const mcpParts = parseMCPToolName(r.tool_name);
+		if (mcpParts) {
+			header += ` source: mcp:${mcpParts.serverName}`;
+		} else {
+			header += ` source: tool:${r.tool_name}`;
+		}
+	} else {
+		header += ` source: ${r.role}`;
+	}
+
+	// Session age
+	header += ` session: ${r.session_id === currentSessionId ? "current" : "other"}`;
 
 	if (r.project_cwd) {
 		header += ` project: ${shortenPath(r.project_cwd)}`;

--- a/packages/coding-agent/test/assembly-summary.test.ts
+++ b/packages/coding-agent/test/assembly-summary.test.ts
@@ -36,6 +36,7 @@ function makeDecision(turnIndex: number, action: TurnDecision["action"], reason:
 		hasToolResults: action === "stubbed",
 		tokensBefore: 1000,
 		tokensAfter: action === "dropped" ? 0 : action === "stubbed" ? 200 : 1000,
+		sourceTags: [],
 	};
 }
 

--- a/packages/coding-agent/test/bridge.test.ts
+++ b/packages/coding-agent/test/bridge.test.ts
@@ -574,3 +574,60 @@ describe("extractPaths (via classify)", () => {
 		expect(result.touchedPaths).toEqual([]);
 	});
 });
+
+// ═══════════════════════════════════════════════════════════════════════════
+// MCP provenance tests
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe("MCP provenance", () => {
+	describe("classifyResult", () => {
+		test("detects MCP tool and sets mcpServerName", () => {
+			const result = classifyResult("mcp_rna_search_symbols", {}, "results", false);
+			expect(result.mcpServerName).toBe("rna");
+			// MCP tools are unknown to TOOL_CATEGORY_MAP, so default to execution/heuristic
+			expect(result.category).toBe("execution");
+			expect(result.trust).toBe("heuristic");
+		});
+
+		test("detects MCP tool with multi-segment server name", () => {
+			const result = classifyResult("mcp_memex_query", {}, "data", false);
+			expect(result.mcpServerName).toBe("memex");
+		});
+
+		test("non-MCP tool has no mcpServerName", () => {
+			const result = classifyResult("read", { path: "a.ts" }, "content", false);
+			expect(result.mcpServerName).toBeUndefined();
+		});
+
+		test("non-MCP tool starting with mcp but not matching pattern has no mcpServerName", () => {
+			const result = classifyResult("mcp", {}, "data", false);
+			expect(result.mcpServerName).toBeUndefined();
+		});
+	});
+
+	describe("bridge locator provenance", () => {
+		test("MCP tool gets mcp:serverName source in provenance", () => {
+			const bridge = createTestBridge();
+			bridge.handleToolResult("mcp_rna_search_symbols", "call-mcp-1", {}, "results", false);
+
+			const locator = bridge.contract.locatorMap[0];
+			expect(locator.provenance.source).toBe("mcp:rna");
+		});
+
+		test("builtin tool gets tool:name source in provenance", () => {
+			const bridge = createTestBridge();
+			bridge.handleToolResult("grep", "call-builtin-1", { pattern: "TODO" }, "matches", false);
+
+			const locator = bridge.contract.locatorMap[0];
+			expect(locator.provenance.source).toBe("tool:grep");
+		});
+
+		test("unknown tool gets tool:name source (not mcp)", () => {
+			const bridge = createTestBridge();
+			bridge.handleToolResult("custom_tool", "call-custom-1", {}, "data", false);
+
+			const locator = bridge.contract.locatorMap[0];
+			expect(locator.provenance.source).toBe("tool:custom_tool");
+		});
+	});
+});

--- a/packages/coding-agent/test/effective-prompt-snapshot.test.ts
+++ b/packages/coding-agent/test/effective-prompt-snapshot.test.ts
@@ -87,6 +87,7 @@ function makeTransformMetadata(overrides?: Partial<TransformMetadata>): Transfor
 				hasToolResults: false,
 				tokensBefore: 50,
 				tokensAfter: 50,
+				sourceTags: [],
 			},
 		],
 		totalTurns: 1,

--- a/packages/coding-agent/test/message-transform.test.ts
+++ b/packages/coding-agent/test/message-transform.test.ts
@@ -3,6 +3,7 @@ import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
 import type { AssistantMessage, DeveloperMessage, ToolResultMessage, UserMessage } from "@oh-my-pi/pi-ai";
 import {
 	DEFAULT_HOT_WINDOW_TURNS,
+	formatStubText,
 	segmentIntoTurns,
 	TOOL_RESULT_STUB_TEXT,
 	transformMessages,
@@ -232,8 +233,8 @@ describe("transformMessages — hot window", () => {
 		expect(toolResults).toHaveLength(4);
 
 		// First two tool_results (old) should have stub content
-		expect(toolResults[0].content).toEqual([{ type: "text", text: TOOL_RESULT_STUB_TEXT }]);
-		expect(toolResults[1].content).toEqual([{ type: "text", text: TOOL_RESULT_STUB_TEXT }]);
+		expect(toolResults[0].content).toEqual([{ type: "text", text: formatStubText(["tool:read"]) }]);
+		expect(toolResults[1].content).toEqual([{ type: "text", text: formatStubText(["tool:read"]) }]);
 
 		// Last two tool_results (hot window) should keep original content
 		expect(toolResults[2].content).toEqual([{ type: "text", text: "recent edit result" }]);
@@ -253,7 +254,7 @@ describe("transformMessages — hot window", () => {
 		const toolResults = result.filter((m): m is ToolResultMessage => m.role === "toolResult");
 
 		// Only the last tool_result should be verbatim
-		expect(toolResults[0].content).toEqual([{ type: "text", text: TOOL_RESULT_STUB_TEXT }]);
+		expect(toolResults[0].content).toEqual([{ type: "text", text: formatStubText(["tool:read"]) }]);
 		expect(toolResults[1].content).toEqual([{ type: "text", text: "content B" }]);
 	});
 
@@ -294,7 +295,7 @@ describe("transformMessages — hot window", () => {
 		)!;
 
 		expect(replacedTr.details).toBeUndefined();
-		expect(replacedTr.content).toEqual([{ type: "text", text: TOOL_RESULT_STUB_TEXT }]);
+		expect(replacedTr.content).toEqual([{ type: "text", text: formatStubText(["tool:read"]) }]);
 	});
 
 	test("tool_use/tool_result pairing preserved after transform", () => {
@@ -417,7 +418,7 @@ describe("transformMessages — budget bounding", () => {
 
 		// Verify the old tool_result was replaced
 		const oldTr = result.find((m): m is ToolResultMessage => m.role === "toolResult" && m.toolCallId === "tc-1")!;
-		expect(oldTr.content).toEqual([{ type: "text", text: TOOL_RESULT_STUB_TEXT }]);
+		expect(oldTr.content).toEqual([{ type: "text", text: formatStubText(["tool:read"]) }]);
 	});
 });
 
@@ -460,7 +461,7 @@ describe("transformMessages — edge cases", () => {
 
 		// All three should be replaced
 		for (const tr of toolResults) {
-			expect(tr.content).toEqual([{ type: "text", text: TOOL_RESULT_STUB_TEXT }]);
+			expect(tr.content).toEqual([{ type: "text", text: formatStubText(["tool:read"]) }]);
 		}
 	});
 
@@ -476,7 +477,7 @@ describe("transformMessages — edge cases", () => {
 
 		const { messages: result } = transformMessages(messages, { hotWindowTurns: 0 });
 		const tr = result.find((m): m is ToolResultMessage => m.role === "toolResult")!;
-		expect(tr.content).toEqual([{ type: "text", text: TOOL_RESULT_STUB_TEXT }]);
+		expect(tr.content).toEqual([{ type: "text", text: formatStubText(["tool:read"]) }]);
 	});
 
 	test("non-tool messages are never modified", () => {
@@ -514,7 +515,7 @@ describe("transformMessages — edge cases", () => {
 		expect(tr.isError).toBe(true);
 		expect(tr.toolCallId).toBe("tc-1");
 		expect(tr.toolName).toBe("bash");
-		expect(tr.content).toEqual([{ type: "text", text: TOOL_RESULT_STUB_TEXT }]);
+		expect(tr.content).toEqual([{ type: "text", text: formatStubText(["tool:bash"]) }]);
 	});
 
 	test("timestamp preserved on replaced tool_result", () => {
@@ -771,5 +772,125 @@ describe("transformMessages — decision metadata", () => {
 		expect(toolTurn.action).toBe("dropped");
 		expect(toolTurn.reason).toBe("budget-exceeded");
 		expect(toolTurn.tokensAfter).toBe(0);
+	});
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Source provenance tags
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe("formatStubText", () => {
+	test("returns default stub when no source tags", () => {
+		expect(formatStubText()).toBe(TOOL_RESULT_STUB_TEXT);
+		expect(formatStubText([])).toBe(TOOL_RESULT_STUB_TEXT);
+	});
+
+	test("includes single source tag", () => {
+		const stub = formatStubText(["tool:grep"]);
+		expect(stub).toContain("source: tool:grep");
+		expect(stub).toContain("Content replaced");
+	});
+
+	test("includes multiple source tags", () => {
+		const stub = formatStubText(["tool:read", "tool:grep"]);
+		expect(stub).toContain("source: tool:read, tool:grep");
+	});
+
+	test("includes MCP source tag", () => {
+		const stub = formatStubText(["mcp:rna"]);
+		expect(stub).toContain("source: mcp:rna");
+	});
+});
+
+describe("TurnDecision sourceTags", () => {
+	test("tool_result turns get source tags from toolName", () => {
+		const messages: AgentMessage[] = [
+			makeUser("start"),
+			makeAssistant([{ id: "tc-1", name: "read" }]),
+			makeToolResult("tc-1", "content"),
+			makeUser("end"),
+		];
+
+		const { metadata } = transformMessages(messages, { hotWindowTurns: 1 });
+		// Turn 0: user, Turn 1: assistant+tool_result, Turn 2: user
+		const toolTurn = metadata.decisions.find(d => d.hasToolResults)!;
+		expect(toolTurn.sourceTags).toEqual(["tool:read"]);
+	});
+
+	test("non-tool turns have empty sourceTags", () => {
+		const messages: AgentMessage[] = [makeUser("hello"), makeAssistant(), makeUser("end")];
+
+		const { metadata } = transformMessages(messages);
+		for (const decision of metadata.decisions) {
+			expect(decision.sourceTags).toEqual([]);
+		}
+	});
+
+	test("MCP tool results get mcp: source tag", () => {
+		const mcpResult: ToolResultMessage = {
+			role: "toolResult",
+			toolCallId: "tc-mcp-1",
+			toolName: "mcp_rna_search_symbols",
+			content: [{ type: "text", text: "symbols found" }],
+			isError: false,
+			timestamp: nextTimestamp(),
+		};
+
+		const messages: AgentMessage[] = [
+			makeAssistant([{ id: "tc-mcp-1", name: "mcp_rna_search_symbols" }]),
+			mcpResult,
+			makeUser("next"),
+		];
+
+		const { metadata } = transformMessages(messages, { hotWindowTurns: 1 });
+		const toolTurn = metadata.decisions.find(d => d.hasToolResults)!;
+		expect(toolTurn.sourceTags).toEqual(["mcp:rna"]);
+	});
+
+	test("sourceTags survive stubbing", () => {
+		const messages: AgentMessage[] = [
+			makeAssistant([{ id: "tc-1", name: "read" }]),
+			makeToolResult("tc-1", "original content"),
+			makeUser("a"),
+			makeUser("b"),
+			makeUser("c"),
+		];
+
+		const { metadata } = transformMessages(messages, { hotWindowTurns: 3 });
+		const stubbedTurn = metadata.decisions.find(d => d.action === "stubbed")!;
+		// Source tags must persist even though content was stubbed
+		expect(stubbedTurn.sourceTags).toEqual(["tool:read"]);
+	});
+
+	test("sourceTags survive budget-dropping", () => {
+		const messages: AgentMessage[] = [
+			makeAssistant([{ id: "tc-1", name: "bash" }]),
+			makeLargeToolResult("tc-1", 40000, "bash"),
+			makeUser("end"),
+		];
+
+		const { metadata } = transformMessages(messages, { hotWindowTurns: 1, maxTokens: 100 });
+		const droppedTurn = metadata.decisions.find(d => d.action === "dropped");
+		if (droppedTurn) {
+			// Source tags must persist even when dropped for budget
+			expect(droppedTurn.sourceTags).toEqual(["tool:bash"]);
+		}
+	});
+
+	test("multiple tools in one turn are deduplicated", () => {
+		const messages: AgentMessage[] = [
+			makeAssistant([
+				{ id: "tc-1", name: "read" },
+				{ id: "tc-2", name: "read" },
+			]),
+			makeToolResult("tc-1", "file A"),
+			makeToolResult("tc-2", "file B"),
+			makeUser("end"),
+		];
+
+		const { metadata } = transformMessages(messages, { hotWindowTurns: 1 });
+		const toolTurn = metadata.decisions.find(d => d.hasToolResults)!;
+		// Two read tool results → deduplicated to single tag
+		expect(toolTurn.sourceTags).toEqual(["tool:read"]);
 	});
 });

--- a/packages/coding-agent/test/passive-hydration.test.ts
+++ b/packages/coding-agent/test/passive-hydration.test.ts
@@ -338,3 +338,71 @@ describe("formatHydratedContext", () => {
 		expect(closeCount).toBe(2);
 	});
 });
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Source provenance and session age
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe("formatHydratedContext — source provenance", () => {
+	test("adds source=tool:name for regular tool results", () => {
+		const results = [makeSearchResult({ text: "grep output", role: "tool_result", tool_name: "grep", turn: 5 })];
+		const formatted = formatHydratedContext(results)!;
+		expect(formatted).toContain('source="tool:grep"');
+	});
+
+	test("adds source=mcp:serverName for MCP tool results", () => {
+		const results = [
+			makeSearchResult({
+				text: "RNA results",
+				role: "tool_result",
+				tool_name: "mcp_rna_search_symbols",
+				turn: 7,
+			}),
+		];
+		const formatted = formatHydratedContext(results)!;
+		expect(formatted).toContain('source="mcp:rna"');
+	});
+
+	test("adds source=role for non-tool results", () => {
+		const results = [makeSearchResult({ text: "user said hello", role: "user", tool_name: null, turn: 1 })];
+		const formatted = formatHydratedContext(results)!;
+		expect(formatted).toContain('source="user"');
+	});
+
+	test("adds session=current when sessionId matches", () => {
+		const results = [makeSearchResult({ text: "recent", session_id: "session-42", turn: 1 })];
+		const formatted = formatHydratedContext(results, "session-42")!;
+		expect(formatted).toContain('session="current"');
+	});
+
+	test("adds session=other when sessionId differs", () => {
+		const results = [makeSearchResult({ text: "old data", session_id: "session-old", turn: 1 })];
+		const formatted = formatHydratedContext(results, "session-new")!;
+		expect(formatted).toContain('session="other"');
+	});
+
+	test("omits session attribute when no currentSessionId provided", () => {
+		const results = [makeSearchResult({ text: "data", turn: 1 })];
+		const formatted = formatHydratedContext(results)!;
+		expect(formatted).not.toContain("session=");
+	});
+
+	test("all attributes present together", () => {
+		const results = [
+			makeSearchResult({
+				text: "search results",
+				role: "tool_result",
+				tool_name: "mcp_memex_query",
+				session_id: "sess-1",
+				turn: 3,
+			}),
+		];
+		const formatted = formatHydratedContext(results, "sess-1")!;
+
+		expect(formatted).toContain('turn="3"');
+		expect(formatted).toContain('role="tool_result"');
+		expect(formatted).toContain('tool="mcp_memex_query"');
+		expect(formatted).toContain('source="mcp:memex"');
+		expect(formatted).toContain('session="current"');
+	});
+});

--- a/packages/coding-agent/test/prompt-inspector-projection.test.ts
+++ b/packages/coding-agent/test/prompt-inspector-projection.test.ts
@@ -101,6 +101,7 @@ function makeTransformMetadata(overrides?: Partial<TransformMetadata>): Transfor
 				hasToolResults: false,
 				tokensBefore: 50,
 				tokensAfter: 50,
+				sourceTags: [],
 			},
 		],
 		totalTurns: 1,
@@ -288,6 +289,7 @@ describe("projectSnapshot", () => {
 			hasToolResults: true,
 			tokensBefore: 500,
 			tokensAfter: 0,
+			sourceTags: [],
 		};
 
 		const snapshot = makeSnapshot({
@@ -535,6 +537,7 @@ describe("projection edge cases", () => {
 						hasToolResults: false,
 						tokensBefore: 50,
 						tokensAfter: 50,
+						sourceTags: [],
 					},
 				],
 			}),

--- a/packages/coding-agent/test/prompt-snapshot-inspector.test.ts
+++ b/packages/coding-agent/test/prompt-snapshot-inspector.test.ts
@@ -91,6 +91,7 @@ function makeDecision(overrides?: Partial<TurnDecision>): TurnDecision {
 		hasToolResults: false,
 		tokensBefore: 50,
 		tokensAfter: 50,
+		sourceTags: [],
 		...overrides,
 	};
 }

--- a/packages/coding-agent/test/recall-tool.test.ts
+++ b/packages/coding-agent/test/recall-tool.test.ts
@@ -100,7 +100,7 @@ describe("RecallTool.execute", () => {
 
 	test("returns empty message when store is empty", async () => {
 		const store = await createStoreWithRows([]);
-		const _tool = new RecallTool(store, "fake-license", "/tmp/test-project");
+		const _tool = new RecallTool(store, "fake-license", "/tmp/test-project", "test-session");
 
 		// We need to mock embed to avoid hitting the real API.
 		// Instead of mocking, let's test the store.search path directly


### PR DESCRIPTION
Closes #59

## Summary

Tag assembled context fragments with their source provenance so the LLM can trace information back to its origin. When multiple knowledge sources (recall, MCP servers, tool results) are assembled into context, the LLM can now identify which source contributed which fact.

### Changes

**Bridge (MCP detection):**
- Added `mcpServerName` to `ResultProfile` via `parseMCPToolName` detection
- MCP tool locator entries now use `source: "mcp:serverName"` instead of `source: "tool:mcp_rna_search_symbols"`

**Message transform (TurnDecision source tags):**
- Added `sourceTags: string[]` to `TurnDecision` for per-turn source attribution
- Added `formatStubText()` that embeds source tags in stub text
- Source tags survive through stubbing and budget-dropping (provenance not lost)

**Recall tool (session age):**
- Added `sessionId` parameter; results now include source tag and session age

**Passive hydration (source + session attributes):**
- Added `source=` and `session=` attributes to `<entry>` tags in recalled context
- MCP tools: `source="mcp:rna"`, builtins: `source="tool:grep"`, non-tool: `source="user"`

### Acceptance Criteria

- [x] Assembled context fragments carry a source tag
- [x] Source boundaries are visible in assembled context (lightweight markers)
- [x] Recall results include session age signal (current session vs other)
- [x] MCP tool results distinguish which MCP server provided them
- [x] Provenance tags survive the stub/hydration cycle

229 tests passing across 7 test files, including new provenance-specific tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Tool results now labeled with source provenance: MCP servers displayed as "mcp:serverName" and built-in tools as "tool:name"
  * Recall results include session age indicators distinguishing current-session data from historical data
  * Source information tracked throughout context assembly and decision-making pipeline

<!-- end of auto-generated comment: release notes by coderabbit.ai -->