### PR TITLE
Budget model: type cleanup and settings contracts

### DIFF
--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -341,6 +341,51 @@ export const SETTINGS_SCHEMA = {
 		},
 	},
 
+	"assembler.safetyMarginPercent": {
+		type: "number",
+		default: 5,
+		ui: {
+			tab: "agent",
+			label: "Safety margin %",
+			description: "Percentage of context window held as safety reserve (0-100)",
+			submenu: true,
+			condition: "isAssemblerMode",
+		},
+	},
+	"assembler.messageBudgetPercent": {
+		type: "number",
+		default: 50,
+		ui: {
+			tab: "agent",
+			label: "Message budget %",
+			description: "Guaranteed minimum percentage of allocatable budget for messages (0-100)",
+			submenu: true,
+			condition: "isAssemblerMode",
+		},
+	},
+	"assembler.hydrationBudgetPercent": {
+		type: "number",
+		default: 50,
+		ui: {
+			tab: "agent",
+			label: "Hydration budget %",
+			description: "Hard cap on hydration as percentage of allocatable budget (0-100)",
+			submenu: true,
+			condition: "isAssemblerMode",
+		},
+	},
+	"assembler.hotWindowTurns": {
+		type: "number",
+		default: 4,
+		ui: {
+			tab: "agent",
+			label: "Hot window turns",
+			description: "Number of recent turns always kept in full (0-20)",
+			submenu: true,
+			condition: "isAssemblerMode",
+		},
+	},
+
 	// ─────────────────────────────────────────────────────────────────────────
 	// Secrets settings
 	// ─────────────────────────────────────────────────────────────────────────
@@ -1409,6 +1454,13 @@ export interface ContextManagerSettings {
 	mode: "legacy" | "shadow" | "assembler";
 }
 
+export interface AssemblerSettings {
+	safetyMarginPercent: number;
+	messageBudgetPercent: number;
+	hydrationBudgetPercent: number;
+	hotWindowTurns: number;
+}
+
 /** Map group prefix -> typed settings interface */
 export interface GroupTypeMap {
 	compaction: CompactionSettings;
@@ -1425,6 +1477,7 @@ export interface GroupTypeMap {
 	stt: SttSettings;
 	modelRoles: Record<string, string>;
 	contextManager: ContextManagerSettings;
+	assembler: AssemblerSettings;
 }
 
 export type ContextManagerMode = SettingValue<"contextManager.mode">;

--- a/packages/coding-agent/src/context/assembler/message-transform.ts
+++ b/packages/coding-agent/src/context/assembler/message-transform.ts
@@ -89,20 +89,24 @@ export function estimateToolDefinitionTokens(
 }
 
 const DEFAULT_MAX_LATENCY_MS = 2000;
-const BUDGET_SAFETY_MARGIN = 0.9;
+const DEFAULT_SAFETY_MARGIN_PERCENT = 5;
+const DEFAULT_MESSAGE_BUDGET_PERCENT = 50;
+const DEFAULT_HYDRATION_BUDGET_PERCENT = 50;
 
 export function deriveBudget(input: BudgetDerivationInput): MemoryAssemblyBudget {
+	const safetyPercent = input.safetyMarginPercent ?? DEFAULT_SAFETY_MARGIN_PERCENT;
+	const messagePercent = input.messageBudgetPercent ?? DEFAULT_MESSAGE_BUDGET_PERCENT;
+	const hydrationPercent = input.hydrationBudgetPercent ?? DEFAULT_HYDRATION_BUDGET_PERCENT;
+
 	const totalCosts = input.systemPromptTokens + input.toolDefinitionTokens + input.currentTurnTokens;
-	const rawAvailable = input.contextWindow - totalCosts;
-	const available = Math.max(0, Math.floor(rawAvailable * BUDGET_SAFETY_MARGIN));
+	const safetyReserve = Math.floor((input.contextWindow * safetyPercent) / 100);
+	const allocatable = Math.max(0, input.contextWindow - totalCosts - safetyReserve);
+
 	return {
-		maxTokens: available,
+		maxTokens: allocatable,
 		maxLatencyMs: DEFAULT_MAX_LATENCY_MS,
-		reservedTokens: {
-			objective: 0,
-			codeContext: 0,
-			executionState: 0,
-		},
+		hydrationBudgetMax: Math.floor((allocatable * hydrationPercent) / 100),
+		messageBudgetMin: Math.floor((allocatable * messagePercent) / 100),
 	};
 }
 

--- a/packages/coding-agent/src/context/assembler/types.ts
+++ b/packages/coding-agent/src/context/assembler/types.ts
@@ -29,4 +29,10 @@ export interface BudgetDerivationInput {
 	toolDefinitionTokens: number;
 	/** Estimated tokens consumed by current-turn messages. */
 	currentTurnTokens: number;
+	/** Percentage of context window held as safety reserve (0-100, default: 5). */
+	safetyMarginPercent?: number;
+	/** Guaranteed minimum percentage of allocatable budget for messages (0-100, default: 50). */
+	messageBudgetPercent?: number;
+	/** Hard cap on hydration as percentage of allocatable budget (0-100, default: 50). */
+	hydrationBudgetPercent?: number;
 }

--- a/packages/coding-agent/src/context/effective-prompt-snapshot.ts
+++ b/packages/coding-agent/src/context/effective-prompt-snapshot.ts
@@ -72,6 +72,10 @@ export interface PromptSnapshotBudget {
 	assembledContextTokens: number;
 	/** Remaining headroom in tokens. */
 	headroom: number;
+	/** Hard ceiling: maximum tokens allocatable to hydration. */
+	hydrationBudgetMax: number;
+	/** Guaranteed floor: minimum tokens reserved for messages. */
+	messageBudgetMin: number;
 }
 
 /**
@@ -186,6 +190,8 @@ export function captureEffectivePromptSnapshot(input: CaptureSnapshotInput): Eff
 					messageTokens,
 					assembledContextTokens,
 					headroom,
+					hydrationBudgetMax: input.assemblerBudget?.hydrationBudgetMax ?? 0,
+					messageBudgetMin: input.assemblerBudget?.messageBudgetMin ?? 0,
 				}
 			: null,
 	};

--- a/packages/coding-agent/src/context/memory-contract.ts
+++ b/packages/coding-agent/src/context/memory-contract.ts
@@ -140,11 +140,10 @@ export interface ShortTermMemoryRecord {
 export interface MemoryAssemblyBudget {
 	maxTokens: number;
 	maxLatencyMs: number;
-	reservedTokens: {
-		objective: number;
-		codeContext: number;
-		executionState: number;
-	};
+	/** Hard ceiling: maximum tokens allocatable to hydration (recalled context). */
+	hydrationBudgetMax: number;
+	/** Guaranteed floor: minimum tokens reserved for conversation messages. */
+	messageBudgetMin: number;
 }
 
 /**

--- a/packages/coding-agent/src/modes/rpc/rpc-types.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-types.ts
@@ -302,6 +302,8 @@ export interface RpcPromptSnapshotBudget {
 	messageTokens: number;
 	assembledContextTokens: number;
 	headroom: number;
+	hydrationBudgetMax: number;
+	messageBudgetMin: number;
 }
 
 /** Report on turn-level composition decisions. */

--- a/packages/coding-agent/test/assembly-summary.test.ts
+++ b/packages/coding-agent/test/assembly-summary.test.ts
@@ -84,6 +84,8 @@ describe("formatAssemblySummary", () => {
 			messageTokens: 50_000,
 			assembledContextTokens: 0,
 			headroom: 142_000,
+			hydrationBudgetMax: 0,
+			messageBudgetMin: 0,
 		};
 		const result = formatAssemblySummary(makeSnapshot({ budget }));
 		expect(result).toContain("Budget:");
@@ -108,6 +110,8 @@ describe("formatAssemblySummary", () => {
 			messageTokens: 50_000,
 			assembledContextTokens: 0,
 			headroom: 142_000,
+			hydrationBudgetMax: 0,
+			messageBudgetMin: 0,
 		};
 		const result = formatAssemblySummary(makeSnapshot({ meta, budget }))!;
 		expect(result).toStartWith("[Assembly: ");
@@ -165,6 +169,8 @@ describe("formatAssemblySummary", () => {
 			messageTokens: 100_000,
 			assembledContextTokens: 5_000,
 			headroom: 17_000,
+			hydrationBudgetMax: 0,
+			messageBudgetMin: 0,
 		};
 		const result = formatAssemblySummary(makeSnapshot({ meta: null, budget }))!;
 		expect(result).toStartWith("[Assembly: Budget:");
@@ -180,6 +186,8 @@ describe("formatAssemblySummary", () => {
 			messageTokens: 0,
 			assembledContextTokens: 0,
 			headroom: 0,
+			hydrationBudgetMax: 0,
+			messageBudgetMin: 0,
 		};
 		const result = formatAssemblySummary(makeSnapshot({ meta: null, budget }));
 		expect(result).toBeNull();

--- a/packages/coding-agent/test/bridge.test.ts
+++ b/packages/coding-agent/test/bridge.test.ts
@@ -460,7 +460,8 @@ describe("ToolResultBridge.rebuildWorkingMemory", () => {
 	const testBudget: MemoryAssemblyBudget = {
 		maxTokens: 50_000,
 		maxLatencyMs: 2000,
-		reservedTokens: { objective: 0, codeContext: 0, executionState: 0 },
+		hydrationBudgetMax: 0,
+		messageBudgetMin: 0,
 	};
 
 	test("populates contract.working from STM state", () => {

--- a/packages/coding-agent/test/effective-prompt-snapshot.test.ts
+++ b/packages/coding-agent/test/effective-prompt-snapshot.test.ts
@@ -108,7 +108,8 @@ function makePacket(overrides?: Partial<WorkingContextPacketV1>): WorkingContext
 		budget: {
 			maxTokens: 40_000,
 			maxLatencyMs: 2000,
-			reservedTokens: { objective: 0, codeContext: 0, executionState: 0 },
+			hydrationBudgetMax: 0,
+			messageBudgetMin: 0,
 		},
 		usage: { consumedTokens: 500, consumedLatencyMs: 100 },
 		fragments: [
@@ -379,7 +380,8 @@ describe("captureEffectivePromptSnapshot", () => {
 		const budget = {
 			maxTokens: 150_000,
 			maxLatencyMs: 2000,
-			reservedTokens: { objective: 0, codeContext: 0, executionState: 0 },
+			hydrationBudgetMax: 0,
+			messageBudgetMin: 0,
 		};
 
 		const input = makeInput({

--- a/packages/coding-agent/test/prompt-inspector-projection.test.ts
+++ b/packages/coding-agent/test/prompt-inspector-projection.test.ts
@@ -122,7 +122,8 @@ function makePacket(overrides?: Partial<WorkingContextPacketV1>): WorkingContext
 		budget: {
 			maxTokens: 40_000,
 			maxLatencyMs: 2000,
-			reservedTokens: { objective: 0, codeContext: 0, executionState: 0 },
+			hydrationBudgetMax: 0,
+			messageBudgetMin: 0,
 		},
 		usage: { consumedTokens: 500, consumedLatencyMs: 100 },
 		fragments: [

--- a/packages/coding-agent/test/prompt-snapshot-inspector.test.ts
+++ b/packages/coding-agent/test/prompt-snapshot-inspector.test.ts
@@ -60,7 +60,8 @@ function makePacket(overrides?: Partial<WorkingContextPacketV1>): WorkingContext
 		budget: {
 			maxTokens: 40_000,
 			maxLatencyMs: 2000,
-			reservedTokens: { objective: 0, codeContext: 0, executionState: 0 },
+			hydrationBudgetMax: 0,
+			messageBudgetMin: 0,
 		},
 		usage: { consumedTokens: 500, consumedLatencyMs: 100 },
 		fragments: [
@@ -139,6 +140,8 @@ function makeSnapshot(overrides?: Partial<EffectivePromptSnapshot>): EffectivePr
 			messageTokens: 150,
 			assembledContextTokens: 0,
 			headroom: 198_150,
+			hydrationBudgetMax: 0,
+			messageBudgetMin: 0,
 		},
 		...overrides,
 	};
@@ -291,6 +294,8 @@ describe("buildPromptSectionDetail", () => {
 				messageTokens: 150,
 				assembledContextTokens: 0,
 				headroom: 198_150,
+				hydrationBudgetMax: 0,
+				messageBudgetMin: 0,
 			},
 		});
 	});


### PR DESCRIPTION
Closes #62

## Summary

Replace dead scaffolding from the scrapped structured retrieval architecture with clean budget types and assembler settings for proportional budget allocation.

### Type changes
- **MemoryAssemblyBudget**: remove reservedTokens (objective, codeContext, executionState -- all hardcoded to 0), add hydrationBudgetMax and messageBudgetMin
- **BudgetDerivationInput**: add safetyMarginPercent, messageBudgetPercent, hydrationBudgetPercent as optional params with defaults
- **PromptSnapshotBudget** and **RpcPromptSnapshotBudget**: add hydrationBudgetMax and messageBudgetMin

### Settings (under assembler.*)
- safetyMarginPercent (default: 5) -- safety reserve as % of context window
- messageBudgetPercent (default: 50) -- guaranteed floor for messages
- hydrationBudgetPercent (default: 50) -- hard cap for hydration
- hotWindowTurns (default: 4) -- recent turns always kept in full

### deriveBudget changes
- Remove BUDGET_SAFETY_MARGIN constant (was 0.9 = 10% margin)
- Compute safety reserve from configurable percentage (default 5%)
- Compute hydrationBudgetMax and messageBudgetMin from configurable percentages of the allocatable budget

### Semantic contract
- messageBudgetPercent is a guaranteed floor (at least X%)
- hydrationBudgetPercent is a hard ceiling (up to X%)
- Independent -- not required to sum to 100
- Each validated in range 0-100 individually

### Behavior change
Safety margin reduced from 10% to 5% of context window. Hydration budget cap and message budget floor introduced. These are intentional -- the old system had no hydration cap and a higher safety margin.

### Files changed (11)
- packages/coding-agent/src/context/memory-contract.ts -- type cleanup
- packages/coding-agent/src/context/assembler/types.ts -- new input fields
- packages/coding-agent/src/context/assembler/message-transform.ts -- deriveBudget redesign
- packages/coding-agent/src/config/settings-schema.ts -- 4 new settings + AssemblerSettings interface
- packages/coding-agent/src/context/effective-prompt-snapshot.ts -- new budget fields
- packages/coding-agent/src/modes/rpc/rpc-types.ts -- RPC budget type update
- 5 test files updated to match new budget shape

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added configurable assembler settings to fine-tune resource allocation with percentage-based safety margins and budget controls.
  * Introduced explicit hydration and message budget constraints for improved context window management.

* **Bug Fixes**
  * Updated budget derivation logic to use percentage-based margins for more predictable resource allocation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->