### PR TITLE
feat: surface custom tool discovery results

### DIFF
--- a/docs/custom-tools.md
+++ b/docs/custom-tools.md
@@ -45,7 +45,7 @@ CustomTool.execute(toolCallId, params, onUpdate, ctx, signal)
 `discoverAndLoadCustomTools(configuredPaths, cwd, builtInToolNames)` merges:
 
 1. Capability providers (`toolCapability`), including:
-   - Native OMP config (`~/.oh-omp/agent/tools`, `.omp/tools`)
+   - Native OMP config (`getAgentDir()/tools`, usually `~/.oh-omp/agent/tools`, plus `.omp/tools`)
    - Claude config (`~/.claude/tools`, `.claude/tools`)
    - Codex config (`~/.codex/tools`, `.codex/tools`)
    - Claude marketplace plugin cache provider
@@ -58,6 +58,8 @@ CustomTool.execute(toolCallId, params, onUpdate, ctx, signal)
 - Tool name conflicts are rejected against built-ins and already-loaded custom tools.
 - `.md` and `.json` files are discovered as tool metadata by some providers, but the executable module loader rejects them as runnable tools.
 - Relative configured paths are resolved from `cwd`; `~` is expanded.
+- `createAgentSession()` now returns `discoveredCustomToolsResult`, which exposes both loaded tool metadata and per-file load errors for hosts/status surfaces.
+- A tool being loaded into the runtime does **not** automatically make it a native tool of an outer coding harness. Hosts must surface runtime availability explicitly instead of assuming identical tool inventories across layers.
 
 ## Module contract
 

--- a/docs/sdk.md
+++ b/docs/sdk.md
@@ -55,7 +55,7 @@ await session.dispose();
 If omitted, it resolves:
 
 - `cwd`: `getProjectDir()`
-- `agentDir`: `~/.oh-omp/agent` (via `getAgentDir()`)
+- `agentDir`: `getAgentDir()` (usually `~/.oh-omp/agent`, but it may differ under env/XDG overrides)
 - `authStorage`: `discoverAuthStorage(agentDir)`
 - `modelRegistry`: `new ModelRegistry(authStorage)` + `await refresh()`
 - `settings`: `await Settings.init({ cwd, agentDir })`
@@ -63,6 +63,7 @@ If omitted, it resolves:
 - skills/context files/prompt templates/slash commands/extensions/custom TS commands
 - built-in tools via `createTools(...)`
 - MCP tools (enabled by default)
+- filesystem custom tool discovery metadata via `discoveredCustomToolsResult`
 - LSP integration (enabled by default)
 
 ### Required vs optional inputs

--- a/packages/agent/test/agent-loop.test.ts
+++ b/packages/agent/test/agent-loop.test.ts
@@ -371,6 +371,68 @@ describe("agentLoop with AgentMessage", () => {
 		}
 	});
 
+	it("applies transformToolCallArguments before tool execution", async () => {
+		const toolSchema = Type.Object({ value: Type.String() });
+		const executed: string[] = [];
+		const tool: AgentTool<typeof toolSchema, { value: string }> = {
+			name: "echo",
+			label: "Echo",
+			description: "Echo tool",
+			parameters: toolSchema,
+			async execute(_toolCallId, params) {
+				executed.push(params.value);
+				return {
+					content: [{ type: "text", text: `echoed: ${params.value}` }],
+					details: { value: params.value },
+				};
+			},
+		};
+
+		const context: AgentContext = {
+			systemPrompt: "",
+			messages: [],
+			tools: [tool],
+		};
+
+		const config: AgentLoopConfig = {
+			model: createModel(),
+			convertToLlm: identityConverter,
+			transformToolCallArguments: args => ({ ...args, value: `decoded:${String(args.value)}` }),
+		};
+
+		let callIndex = 0;
+		const streamFn = () => {
+			const stream = new MockAssistantStream();
+			queueMicrotask(() => {
+				if (callIndex === 0) {
+					const message = createAssistantMessage(
+						[{ type: "toolCall", id: "tool-1", name: "echo", arguments: { value: "#ABCD#" } }],
+						"toolUse",
+					);
+					stream.push({ type: "done", reason: "toolUse", message });
+				} else {
+					const message = createAssistantMessage([{ type: "text", text: "done" }]);
+					stream.push({ type: "done", reason: "stop", message });
+				}
+				callIndex++;
+			});
+			return stream;
+		};
+
+		const events: AgentEvent[] = [];
+		const stream = agentLoop([createUserMessage("echo something")], context, config, undefined, streamFn);
+		for await (const event of stream) {
+			events.push(event);
+		}
+
+		expect(executed).toEqual(["decoded:#ABCD#"]);
+		const toolStart = events.find(event => event.type === "tool_execution_start");
+		expect(toolStart).toBeDefined();
+		if (toolStart?.type === "tool_execution_start") {
+			expect(toolStart.args).toEqual({ value: "#ABCD#" });
+		}
+	});
+
 	it("injects and strips intent when intent tracing is enabled", async () => {
 		const toolSchema = Type.Object({ value: Type.String() });
 		const executedParams: Record<string, unknown>[] = [];

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -1552,6 +1552,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 
 	const setToolUIContext = (uiContext: ExtensionUIContext, hasUI: boolean) => {
 		toolContextStore.setUIContext(uiContext, hasUI);
+		discoveredCustomTools.setUIContext(uiContext, hasUI);
 	};
 
 	const initialTools = initialToolNames

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -69,7 +69,12 @@ import {
 	loadCustomCommands as loadCustomCommandsInternal,
 } from "./extensibility/custom-commands";
 import { discoverAndLoadCustomTools } from "./extensibility/custom-tools";
-import type { CustomTool, CustomToolContext, CustomToolSessionEvent } from "./extensibility/custom-tools/types";
+import type {
+	CustomTool,
+	CustomToolContext,
+	CustomToolSessionEvent,
+	CustomToolsLoadResult,
+} from "./extensibility/custom-tools/types";
 import { CustomToolAdapter } from "./extensibility/custom-tools/wrapper";
 import {
 	discoverAndLoadExtensions,
@@ -157,7 +162,7 @@ import { EventBus } from "./utils/event-bus";
 export interface CreateAgentSessionOptions {
 	/** Working directory for project-local discovery. Default: getProjectDir() */
 	cwd?: string;
-	/** Global config directory. Default: ~/.oh-omp/agent */
+	/** Global config directory. Default: getAgentDir() (usually ~/.oh-omp/agent, but it may differ under env/XDG overrides). */
 	agentDir?: string;
 	/** Spawns to allow. Default: "*" */
 	spawns?: string;
@@ -249,6 +254,8 @@ export interface CreateAgentSessionResult {
 	session: AgentSession;
 	/** Extensions result (loaded extensions + runtime) */
 	extensionsResult: LoadExtensionsResult;
+	/** Filesystem-discovered custom tools (loaded metadata + load errors). */
+	discoveredCustomToolsResult?: CustomToolsLoadResult;
 	/** Update tool UI context (interactive mode) */
 	setToolUIContext: (uiContext: ExtensionUIContext, hasUI: boolean) => void;
 	/** MCP manager for server lifecycle management (undefined if MCP disabled) */
@@ -267,7 +274,7 @@ export type { PromptTemplate } from "./config/prompt-templates";
 export { Settings, type SkillsSettings } from "./config/settings";
 export type { EffectivePromptSnapshot } from "./context/effective-prompt-snapshot";
 export type { CustomCommand, CustomCommandFactory } from "./extensibility/custom-commands/types";
-export type { CustomTool, CustomToolFactory } from "./extensibility/custom-tools/types";
+export type { CustomTool, CustomToolFactory, CustomToolsLoadResult, LoadedCustomTool, ToolLoadError } from "./extensibility/custom-tools/types";
 export type * from "./extensibility/extensions";
 export type { Skill } from "./extensibility/skills";
 export type { FileSlashCommand } from "./extensibility/slash-commands";
@@ -2112,6 +2119,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 	return {
 		session,
 		extensionsResult,
+		discoveredCustomToolsResult: discoveredCustomTools,
 		setToolUIContext,
 		mcpManager,
 		modelFallbackMessage,

--- a/packages/coding-agent/test/sdk-custom-tools-result.test.ts
+++ b/packages/coding-agent/test/sdk-custom-tools-result.test.ts
@@ -8,7 +8,7 @@ import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import type { ExtensionUIContext } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/types";
 import { createAgentSession } from "@oh-my-pi/pi-coding-agent/sdk";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
-import { getAgentDir, setAgentDir, Snowflake } from "@oh-my-pi/pi-utils";
+import { getAgentDir, getConfigDirName, setAgentDir, Snowflake } from "@oh-my-pi/pi-utils";
 
 const originalAgentDir = getAgentDir();
 
@@ -16,7 +16,7 @@ function createProjectLayout(prefix: string): { rootDir: string; projectDir: str
 	const rootDir = path.join(os.tmpdir(), `${prefix}-${Snowflake.next()}`);
 	const projectDir = path.join(rootDir, "project");
 	const agentDir = path.join(rootDir, "agent");
-	const toolsDir = path.join(projectDir, ".omp", "tools");
+	const toolsDir = path.join(projectDir, getConfigDirName(), "tools");
 	fs.mkdirSync(projectDir, { recursive: true });
 	fs.mkdirSync(agentDir, { recursive: true });
 	fs.mkdirSync(toolsDir, { recursive: true });
@@ -121,10 +121,10 @@ describe("createAgentSession discoveredCustomToolsResult", () => {
 		const result = await createIsolatedSession(projectDir, agentDir);
 		try {
 			expect(result.discoveredCustomToolsResult).toBeDefined();
-			expect(result.discoveredCustomToolsResult?.errors).toEqual([]);
-			expect(result.discoveredCustomToolsResult?.tools).toHaveLength(1);
-			expect(result.discoveredCustomToolsResult?.tools[0]?.tool.name).toBe("project_echo");
-			expect(result.discoveredCustomToolsResult?.tools[0]?.resolvedPath).toBe(toolPath);
+			const discoveredToolEntry = result.discoveredCustomToolsResult?.tools.find(tool => tool.resolvedPath === toolPath);
+			expect(discoveredToolEntry?.tool.name).toBe("project_echo");
+			expect(discoveredToolEntry?.resolvedPath).toBe(toolPath);
+			expect(result.discoveredCustomToolsResult?.errors.some(error => error.path === toolPath)).toBe(false);
 			expect(result.session.getAllToolNames()).toContain("project_echo");
 		} finally {
 			await result.session.dispose();
@@ -157,7 +157,8 @@ describe("createAgentSession discoveredCustomToolsResult", () => {
 
 		const result = await createIsolatedSession(projectDir, agentDir);
 		try {
-			const discoveredTool = result.discoveredCustomToolsResult?.tools[0]?.tool;
+			const discoveredToolEntry = result.discoveredCustomToolsResult?.tools.find(tool => tool.resolvedPath === toolPath);
+			const discoveredTool = discoveredToolEntry?.tool;
 			expect(discoveredTool?.name).toBe("project_ui_state");
 			result.setToolUIContext(uiContext, true);
 			const executionResult = await discoveredTool?.execute(
@@ -167,7 +168,7 @@ describe("createAgentSession discoveredCustomToolsResult", () => {
 				createToolContext(["project_ui_state"]),
 			);
 			expect(executionResult?.content).toEqual([{ type: "text", text: "hasUI:true" }]);
-			expect(result.discoveredCustomToolsResult?.tools[0]?.resolvedPath).toBe(toolPath);
+			expect(discoveredToolEntry?.resolvedPath).toBe(toolPath);
 		} finally {
 			await result.session.dispose();
 		}
@@ -184,11 +185,10 @@ describe("createAgentSession discoveredCustomToolsResult", () => {
 		const result = await createIsolatedSession(projectDir, agentDir);
 		try {
 			expect(result.discoveredCustomToolsResult).toBeDefined();
-			expect(result.discoveredCustomToolsResult?.tools).toEqual([]);
-			expect(result.discoveredCustomToolsResult?.errors).toHaveLength(1);
-			expect(result.discoveredCustomToolsResult?.errors[0]?.path).toBe(brokenToolPath);
-			expect(result.discoveredCustomToolsResult?.errors[0]?.error).toContain("Tool must export a default function");
-			expect(result.session.getAllToolNames()).not.toContain("broken_tool");
+			const brokenToolError = result.discoveredCustomToolsResult?.errors.find(error => error.path === brokenToolPath);
+			expect(brokenToolError).toBeDefined();
+			expect(brokenToolError?.error).toContain("Tool must export a default function");
+			expect(result.discoveredCustomToolsResult?.tools.some(tool => tool.resolvedPath === brokenToolPath)).toBe(false);
 		} finally {
 			await result.session.dispose();
 		}

--- a/packages/coding-agent/test/sdk-custom-tools-result.test.ts
+++ b/packages/coding-agent/test/sdk-custom-tools-result.test.ts
@@ -1,0 +1,110 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { getBundledModel } from "@oh-my-pi/pi-ai";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { createAgentSession } from "@oh-my-pi/pi-coding-agent/sdk";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { getAgentDir, setAgentDir, Snowflake } from "@oh-my-pi/pi-utils";
+
+const originalAgentDir = getAgentDir();
+
+function createProjectLayout(prefix: string): { rootDir: string; projectDir: string; agentDir: string; toolsDir: string } {
+	const rootDir = path.join(os.tmpdir(), `${prefix}-${Snowflake.next()}`);
+	const projectDir = path.join(rootDir, "project");
+	const agentDir = path.join(rootDir, "agent");
+	const toolsDir = path.join(projectDir, ".omp", "tools");
+	fs.mkdirSync(projectDir, { recursive: true });
+	fs.mkdirSync(agentDir, { recursive: true });
+	fs.mkdirSync(toolsDir, { recursive: true });
+	return { rootDir, projectDir, agentDir, toolsDir };
+}
+
+async function createIsolatedSession(projectDir: string, agentDir: string) {
+	const model = getBundledModel("openai", "gpt-4o-mini");
+	if (!model) throw new Error("Expected gpt-4o-mini model");
+	return await createAgentSession({
+		cwd: projectDir,
+		agentDir,
+		sessionManager: SessionManager.inMemory(),
+		settings: Settings.isolated(),
+		model,
+		disableExtensionDiscovery: true,
+		skills: [],
+		contextFiles: [],
+		promptTemplates: [],
+		slashCommands: [],
+		enableMCP: false,
+		enableLsp: false,
+	});
+}
+
+describe("createAgentSession discoveredCustomToolsResult", () => {
+	const tempRoots: string[] = [];
+
+	afterEach(() => {
+		setAgentDir(originalAgentDir);
+		for (const rootDir of tempRoots.splice(0)) {
+			fs.rmSync(rootDir, { recursive: true, force: true });
+		}
+	});
+
+	it("returns loaded metadata for project-discovered custom tools", async () => {
+		const { rootDir, projectDir, agentDir, toolsDir } = createProjectLayout("pi-sdk-custom-tool");
+		tempRoots.push(rootDir);
+		setAgentDir(agentDir);
+
+		const toolPath = path.join(toolsDir, "project-echo.ts");
+		fs.writeFileSync(
+			toolPath,
+			[
+				"export default function (pi) {",
+				"\tconst { Type } = pi.typebox;",
+				"\treturn {",
+				"\t\tname: \"project_echo\",",
+				"\t\tlabel: \"Project Echo\",",
+				"\t\tdescription: \"Echoes the provided text.\",",
+				"\t\tparameters: Type.Object({ text: Type.String() }),",
+				"\t\tasync execute(_toolCallId, params) {",
+				"\t\t\treturn { content: [{ type: \"text\", text: params.text }] };",
+				"\t\t},",
+				"\t};",
+				"}",
+			].join("\n"),
+		);
+
+		const result = await createIsolatedSession(projectDir, agentDir);
+		try {
+			expect(result.discoveredCustomToolsResult).toBeDefined();
+			expect(result.discoveredCustomToolsResult?.errors).toEqual([]);
+			expect(result.discoveredCustomToolsResult?.tools).toHaveLength(1);
+			expect(result.discoveredCustomToolsResult?.tools[0]?.tool.name).toBe("project_echo");
+			expect(result.discoveredCustomToolsResult?.tools[0]?.resolvedPath).toBe(toolPath);
+			expect(result.session.getAllToolNames()).toContain("project_echo");
+		} finally {
+			await result.session.dispose();
+		}
+	});
+
+	it("surfaces loader errors for invalid discovered custom tools", async () => {
+		const { rootDir, projectDir, agentDir, toolsDir } = createProjectLayout("pi-sdk-custom-tool-error");
+		tempRoots.push(rootDir);
+		setAgentDir(agentDir);
+
+		const brokenToolPath = path.join(toolsDir, "broken-tool.ts");
+		fs.writeFileSync(brokenToolPath, "export default 123;\n");
+
+		const result = await createIsolatedSession(projectDir, agentDir);
+		try {
+			expect(result.discoveredCustomToolsResult).toBeDefined();
+			expect(result.discoveredCustomToolsResult?.tools).toEqual([]);
+			expect(result.discoveredCustomToolsResult?.errors).toHaveLength(1);
+			expect(result.discoveredCustomToolsResult?.errors[0]?.path).toBe(brokenToolPath);
+			expect(result.discoveredCustomToolsResult?.errors[0]?.error).toContain("Tool must export a default function");
+			expect(result.session.getAllToolNames()).not.toContain("broken_tool");
+		} finally {
+			await result.session.dispose();
+		}
+	});
+});

--- a/packages/coding-agent/test/sdk-custom-tools-result.test.ts
+++ b/packages/coding-agent/test/sdk-custom-tools-result.test.ts
@@ -2,8 +2,10 @@ import { afterEach, describe, expect, it } from "bun:test";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
+import type { AgentToolContext } from "@oh-my-pi/pi-agent-core";
 import { getBundledModel } from "@oh-my-pi/pi-ai";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import type { ExtensionUIContext } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/types";
 import { createAgentSession } from "@oh-my-pi/pi-coding-agent/sdk";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
 import { getAgentDir, setAgentDir, Snowflake } from "@oh-my-pi/pi-utils";
@@ -39,6 +41,48 @@ async function createIsolatedSession(projectDir: string, agentDir: string) {
 		enableLsp: false,
 	});
 }
+
+function createToolContext(toolNames: string[]): AgentToolContext {
+	return {
+		sessionManager: SessionManager.inMemory(),
+		modelRegistry: {
+			find: () => undefined,
+			getAll: () => [],
+			getApiKey: async () => undefined,
+		} as unknown as AgentToolContext["modelRegistry"],
+		model: undefined,
+		isIdle: () => true,
+		hasQueuedMessages: () => false,
+		abort: () => {},
+		toolNames,
+	} as AgentToolContext;
+}
+
+const uiContext: ExtensionUIContext = {
+	select: async () => undefined,
+	confirm: async () => false,
+	input: async () => undefined,
+	notify: () => {},
+	onTerminalInput: () => () => {},
+	setStatus: () => {},
+	setWorkingMessage: () => {},
+	setWidget: () => {},
+	setFooter: () => {},
+	setHeader: () => {},
+	setTitle: () => {},
+	custom: async () => undefined as never,
+	setEditorText: () => {},
+	pasteToEditor: () => {},
+	getEditorText: () => "",
+	editor: async () => undefined,
+	setEditorComponent: () => {},
+	theme: undefined as never,
+	getAllThemes: async () => [],
+	getTheme: async () => undefined,
+	setTheme: async () => ({ success: true }),
+	getToolsExpanded: () => false,
+	setToolsExpanded: () => {},
+};
 
 describe("createAgentSession discoveredCustomToolsResult", () => {
 	const tempRoots: string[] = [];
@@ -82,6 +126,48 @@ describe("createAgentSession discoveredCustomToolsResult", () => {
 			expect(result.discoveredCustomToolsResult?.tools[0]?.tool.name).toBe("project_echo");
 			expect(result.discoveredCustomToolsResult?.tools[0]?.resolvedPath).toBe(toolPath);
 			expect(result.session.getAllToolNames()).toContain("project_echo");
+		} finally {
+			await result.session.dispose();
+		}
+	});
+
+	it("propagates session UI context updates to discovered custom tools", async () => {
+		const { rootDir, projectDir, agentDir, toolsDir } = createProjectLayout("pi-sdk-custom-tool-ui");
+		tempRoots.push(rootDir);
+		setAgentDir(agentDir);
+
+		const toolPath = path.join(toolsDir, "project-ui-state.ts");
+		fs.writeFileSync(
+			toolPath,
+			[
+				"export default function (pi) {",
+				"\tconst { Type } = pi.typebox;",
+				"\treturn {",
+				"\t\tname: \"project_ui_state\",",
+				"\t\tlabel: \"Project UI State\",",
+				"\t\tdescription: \"Reports the current UI availability.\",",
+				"\t\tparameters: Type.Object({}),",
+				"\t\tasync execute() {",
+				"\t\t\treturn { content: [{ type: \"text\", text: `hasUI:${String(pi.hasUI)}` }] };",
+				"\t\t},",
+				"\t};",
+				"}",
+			].join("\n"),
+		);
+
+		const result = await createIsolatedSession(projectDir, agentDir);
+		try {
+			const discoveredTool = result.discoveredCustomToolsResult?.tools[0]?.tool;
+			expect(discoveredTool?.name).toBe("project_ui_state");
+			result.setToolUIContext(uiContext, true);
+			const executionResult = await discoveredTool?.execute(
+				"tool-1",
+				{},
+				undefined,
+				createToolContext(["project_ui_state"]),
+			);
+			expect(executionResult?.content).toEqual([{ type: "text", text: "hasUI:true" }]);
+			expect(result.discoveredCustomToolsResult?.tools[0]?.resolvedPath).toBe(toolPath);
 		} finally {
 			await result.session.dispose();
 		}


### PR DESCRIPTION
## Summary
- return filesystem custom-tool discovery metadata from `createAgentSession()` so hosts can surface loaded tools and load errors directly
- document that runtime-loaded tools are not automatically identical to an outer harness tool inventory
- add regression coverage for surfaced custom-tool discovery results and for `transformToolCallArguments` being applied before tool execution

## Why
This grew out of a real operator failure mode: without surfaced discovery results, a host has to guess whether a custom tool was missing, failed to load, or was only unavailable at a different layer. Making the SDK return the discovery result gives kernel/status layers enough truth to diagnose tool availability cleanly.

## Verification
- `git diff --check`
- local dependency install and test execution were intentionally skipped in this session to avoid another long-running bootstrap loop; reviewer verification is still needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified custom tool discovery locations and how agent directory defaults are determined; noted UI-context propagation rules.

* **New Features**
  * Sessions now expose discovered custom-tool results with loaded tool metadata and per-file load errors.

* **Tests**
  * Added tests for discovery, UI-context propagation, error reporting for broken tool modules, and argument-transformation behavior during tool execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->