### PR TITLE
fix: ad-hoc codesign macOS binary in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,12 @@ jobs:
         env:
           PI_RELEASE_VERSION: ${{ github.ref_name }}
 
+      - name: Ad-hoc codesign (macOS)
+        if: matrix.platform == 'darwin'
+        run: |
+          codesign --remove-signature packages/coding-agent/dist/oh-omp
+          codesign -s - packages/coding-agent/dist/oh-omp
+
       - uses: actions/upload-artifact@v4
         with:
           name: oh-omp-${{ matrix.platform }}-${{ matrix.arch }}


### PR DESCRIPTION
## Summary
- `bun build --compile` produces macOS binaries with an invalid `LC_CODE_SIGNATURE` region
- macOS Sequoia enforces signature validation and SIGKILL's the binary before it can run
- The npm wrapper translates this to a silent exit code 1, making the failure hard to diagnose
- Adds a post-build step on the darwin matrix runner to strip the broken signature and apply a valid ad-hoc signature (`codesign -s -`)

## Test plan
- [ ] Tag a release and verify the darwin-arm64 artifact passes `codesign -v`
- [ ] Install the published package on macOS Sequoia and confirm `oh-omp --version` works without manual xattr/codesign workarounds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced macOS build process with an additional post-build step for binary signing to ensure proper artifact handling before upload.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->