### PR TITLE
feat(coding-agent): add manual fact store MVP

### DIFF
--- a/docs/adr/0005-fact-store-belief-layer.md
+++ b/docs/adr/0005-fact-store-belief-layer.md
@@ -1,0 +1,142 @@
+# ADR 0005: Fact Store Belief Layer
+
+- Status: Proposed
+- Date: 2026-04-24
+- Decision makers: Harness maintainers
+- Depends on: ADR 0003 (tiered memory + assembler), ADR 0004 (tool-result-to-memory bridge)
+
+## Context
+
+oh-omp has two adjacent continuity systems:
+
+- **Recall** stores evidence-shaped snippets for similar past context.
+- **Memory artifacts** synthesize guidance, workflows, lessons, and locator-backed context.
+
+Neither is designed to answer “what current scoped facts should the assistant believe?” Users still need to restate durable preferences, project decisions, owners, dates, and corrections across sessions.
+
+A Fact Store introduces a third tier: a small, local belief database for normalized assertions with provenance and correction semantics. The dissent on this decision found that the direction is right, but the first slice must be conservative enough to avoid trust, privacy, and ontology debt.
+
+## Decision
+
+Introduce a dedicated `facts` module, but constrain the first implementation slice to **manual collection only**.
+
+The initial Fact Store is:
+
+1. Separate from recall and memory.
+2. Local to the agent data directory.
+3. Backed by SQLite.
+4. Allowlisted by fact kind, not arbitrary ontology predicates.
+5. Resolver-on-read, with no materialized `fact_current` table yet.
+6. Explicit about privacy deletion vs belief retraction.
+7. Safe for bounded prompt injection, but not automatically wired into assembly until the injection behavior is proven.
+
+## First-Slice Scope
+
+### Collection
+
+Allowed in the first slice:
+
+- CLI/manual add.
+- In-session `/facts add`.
+- Explicit “remember that …” can be mapped to manual add in a later slice.
+
+Not allowed in the first slice:
+
+- Autonomous extraction.
+- Auto-promotion from `.oh/*.md` files.
+- Auto-promotion from assistant-authored plans.
+- Auto-extraction of personal or sensitive facts.
+
+### Fact kinds
+
+The first slice uses a small allowlist:
+
+- `user_preference`
+- `project_decision`
+- `project_constraint`
+- `date_deadline`
+- `ownership`
+- `environment_tooling`
+
+Each fact still stores `subject`, `predicate`, and JSON `object`, but `kind` is the primary contract. Arbitrary predicates are allowed only inside an allowlisted kind and can be tightened later once dogfood data shows repeated patterns.
+
+### Privacy and deletion
+
+The store distinguishes two operations:
+
+- **Retract**: marks an assertion as no longer active while preserving history and explanation.
+- **Erase**: redacts object, canonical text, evidence, supersession, and tags for privacy. It is the operation users need when “forget” means payload removal.
+
+Secret facts are rejected by the manual path. Sensitive facts require a future explicit-consent flow and are not injected by default.
+
+### Resolution
+
+The first slice resolves on read:
+
+- `active` facts are candidates.
+- `retracted`, `erased`, `superseded`, `expired`, and `disputed` facts are omitted from active results by default.
+- Expired facts are omitted unless history is requested.
+- Source authority and recency are used to select one active assertion for the same subject/predicate/scope.
+- Current user instructions, repo state, runtime output, and explicit corrections still outrank stored facts.
+
+No `fact_current` table is created until resolver rules stabilize.
+
+### Prompt injection
+
+The module may format a `<known-facts>` block, but assembly wiring must stay bounded and separately reviewed:
+
+- Max fact count.
+- Max character budget.
+- Omission reasons for debug traces.
+- No `secret` or `sensitive` facts.
+- No `personal` facts unless explicitly allowed.
+- A precedence note that current user/repo/runtime evidence outranks stored facts.
+
+The Fact Store supplies scoped beliefs. It does not become a second context manager.
+
+## Consequences
+
+### Positive
+
+- Preserves clean boundaries: recall is evidence, memory is guidance, facts are beliefs.
+- Gives users inspectable and correctable continuity.
+- Keeps autonomous extraction out until trust is proven.
+- Avoids early schema debt from a large ontology or graph model.
+- Keeps assembler cutover constraints intact.
+
+### Negative
+
+- Manual-first collection means slower initial accumulation.
+- Resolver-on-read may need optimization later.
+- Users must learn another visible continuity surface.
+- The allowlist may reject useful facts until the schema evolves.
+
+## Implementation Notes
+
+Initial files live under:
+
+```text
+packages/coding-agent/src/facts/
+├── index.ts
+├── prompt-format.ts
+├── resolver.ts
+├── schema.ts
+└── storage.ts
+```
+
+Manual command surfaces:
+
+- `oh-omp facts add ...`
+- `oh-omp facts view`
+- `oh-omp facts search ...`
+- `oh-omp facts explain ...`
+- `oh-omp facts retract ...`
+- `oh-omp facts erase ...`
+- `/facts ...` delegates to the same command logic in interactive mode.
+
+## Open Questions
+
+- When should explicit natural-language “remember that …” become a structured manual add flow?
+- What consent UX is acceptable for personal facts?
+- When is it safe to add candidate extraction and review?
+- Which predicates recur often enough to become a stricter schema?

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -259,6 +259,14 @@
 			"types": "./src/extensibility/plugins/*.ts",
 			"import": "./src/extensibility/plugins/*.ts"
 		},
+		"./facts": {
+			"types": "./src/facts/index.ts",
+			"import": "./src/facts/index.ts"
+		},
+		"./facts/*": {
+			"types": "./src/facts/*.ts",
+			"import": "./src/facts/*.ts"
+		},
 		"./internal-urls": {
 			"types": "./src/internal-urls/index.ts",
 			"import": "./src/internal-urls/index.ts"

--- a/packages/coding-agent/src/cli.ts
+++ b/packages/coding-agent/src/cli.ts
@@ -48,6 +48,7 @@ const commands: CommandEntry[] = [
 	{ name: "commit", load: () => import("./commands/commit").then(m => m.default) },
 	{ name: "config", load: () => import("./commands/config").then(m => m.default) },
 	{ name: "grep", load: () => import("./commands/grep").then(m => m.default) },
+	{ name: "facts", load: () => import("./commands/facts").then(m => m.default) },
 	{ name: "jupyter", load: () => import("./commands/jupyter").then(m => m.default) },
 	{ name: "plugin", load: () => import("./commands/plugin").then(m => m.default) },
 	{ name: "setup", load: () => import("./commands/setup").then(m => m.default) },

--- a/packages/coding-agent/src/cli/facts-cli.ts
+++ b/packages/coding-agent/src/cli/facts-cli.ts
@@ -1,0 +1,257 @@
+import { getAgentDir } from "@oh-my-pi/pi-utils";
+import { formatKnownFactsBlock } from "../facts/prompt-format";
+import {
+	FACT_KINDS,
+	FACT_SCOPE_KINDS,
+	FACT_SENSITIVITIES,
+	type FactAssertion,
+	type FactScope,
+	type FactScopeKind,
+	type FactSensitivity,
+	isFactKind,
+	isFactScopeKind,
+	isFactSensitivity,
+} from "../facts/schema";
+import { FactStore, getFactsDbPath } from "../facts/storage";
+
+export type FactsAction = "add" | "view" | "search" | "explain" | "retract" | "erase" | "path" | "prompt";
+
+export interface FactsCommandArgs {
+	action: FactsAction;
+	values: string[];
+	flags: {
+		json?: boolean;
+		all?: boolean;
+		scope?: string;
+		sensitivity?: string;
+		canonical?: string;
+		limit?: number;
+		db?: string;
+		includePersonal?: boolean;
+	};
+}
+
+export interface FactsCommandOptions {
+	agentDir?: string;
+	cwd?: string;
+	write?: (text: string) => void;
+}
+
+const FACTS_ACTIONS: FactsAction[] = ["add", "view", "search", "explain", "retract", "erase", "path", "prompt"];
+
+export function parseFactsArgv(argv: string[]): FactsCommandArgs {
+	const action = (argv[0] ?? "view") as FactsAction;
+	if (!FACTS_ACTIONS.includes(action)) {
+		throw new Error(`Unknown facts command: ${action}. Valid commands: ${FACTS_ACTIONS.join(", ")}`);
+	}
+	const flags: FactsCommandArgs["flags"] = {};
+	const values: string[] = [];
+	for (let i = 1; i < argv.length; i++) {
+		const arg = argv[i];
+		if (action === "add" && values.length >= 3) {
+			values.push(arg);
+			continue;
+		}
+		if (arg === "--json") {
+			flags.json = true;
+		} else if (arg === "--all") {
+			flags.all = true;
+		} else if (arg === "--include-personal") {
+			flags.includePersonal = true;
+		} else if (arg === "--scope") {
+			flags.scope = readFlagValue(argv, ++i, "--scope");
+		} else if (arg === "--sensitivity") {
+			flags.sensitivity = readFlagValue(argv, ++i, "--sensitivity");
+		} else if (arg === "--canonical") {
+			flags.canonical = readFlagValue(argv, ++i, "--canonical");
+		} else if (arg === "--limit") {
+			flags.limit = Number(readFlagValue(argv, ++i, "--limit"));
+		} else if (arg === "--db") {
+			flags.db = readFlagValue(argv, ++i, "--db");
+		} else if (arg.startsWith("--")) {
+			throw new Error(`Unknown facts flag: ${arg}`);
+		} else {
+			values.push(arg);
+		}
+	}
+	return { action, values, flags };
+}
+
+export async function runFactsCommand(cmd: FactsCommandArgs, options: FactsCommandOptions = {}): Promise<string> {
+	const agentDir = options.agentDir ?? getAgentDir();
+	const cwd = options.cwd ?? process.cwd();
+	const dbPath = cmd.flags.db ?? getFactsDbPath(agentDir);
+	if (cmd.action === "path") {
+		return emit(dbPath, options.write);
+	}
+
+	const store = FactStore.open(dbPath);
+	try {
+		const output = handleFactsCommand(store, cmd, cwd);
+		return emit(output, options.write);
+	} finally {
+		store.close();
+	}
+}
+
+function handleFactsCommand(store: FactStore, cmd: FactsCommandArgs, cwd: string): string {
+	switch (cmd.action) {
+		case "add":
+			return handleAdd(store, cmd, cwd);
+		case "view":
+			return handleView(store, cmd);
+		case "search":
+			return handleSearch(store, cmd);
+		case "explain":
+			return handleExplain(store, cmd);
+		case "retract":
+			return handleRetract(store, cmd);
+		case "erase":
+			return handleErase(store, cmd);
+		case "prompt":
+			return handlePrompt(store, cmd);
+		case "path":
+			throw new Error("facts path is handled before storage opens.");
+	}
+}
+
+function handleAdd(store: FactStore, cmd: FactsCommandArgs, cwd: string): string {
+	const [kindRaw, subject, predicate, ...objectParts] = cmd.values;
+	if (!kindRaw || !subject || !predicate || objectParts.length === 0) {
+		throw new Error(`Usage: facts add <kind> <subject> <predicate> <value>. Kinds: ${FACT_KINDS.join(", ")}`);
+	}
+	if (!isFactKind(kindRaw)) {
+		throw new Error(`Invalid fact kind: ${kindRaw}. Kinds: ${FACT_KINDS.join(", ")}`);
+	}
+	const sensitivity = parseSensitivity(cmd.flags.sensitivity);
+	const objectRaw = objectParts.join(" ");
+	const object = parseObjectValue(objectRaw);
+	const canonicalText = cmd.flags.canonical ?? `${subject} ${predicate}: ${formatObjectValue(object)}`;
+	const fact = store.add({
+		kind: kindRaw,
+		subject,
+		predicate,
+		object,
+		canonicalText,
+		scope: buildScope(cmd.flags.scope, cwd),
+		sensitivity,
+		source: { kind: "manual" },
+	});
+	if (cmd.flags.json) return JSON.stringify(fact, null, 2);
+	return `Added fact ${fact.id}\n${formatFactLine(fact)}`;
+}
+
+function handleView(store: FactStore, cmd: FactsCommandArgs): string {
+	const facts = store.list({ includeHistory: cmd.flags.all, limit: cmd.flags.limit });
+	if (cmd.flags.json) return JSON.stringify(facts, null, 2);
+	if (facts.length === 0) return cmd.flags.all ? "No facts stored." : "No active facts stored.";
+	return facts.map(formatFactLine).join("\n");
+}
+
+function handleSearch(store: FactStore, cmd: FactsCommandArgs): string {
+	const query = cmd.values.join(" ").trim();
+	if (!query) throw new Error("Usage: facts search <query>");
+	const facts = store.search({ query, includeHistory: cmd.flags.all, limit: cmd.flags.limit });
+	if (cmd.flags.json) return JSON.stringify(facts, null, 2);
+	if (facts.length === 0) return "No matching facts.";
+	return facts.map(formatFactLine).join("\n");
+}
+
+function handleExplain(store: FactStore, cmd: FactsCommandArgs): string {
+	const id = cmd.values[0];
+	if (!id) throw new Error("Usage: facts explain <id>");
+	const fact = store.get(id);
+	if (!fact) return `Fact not found: ${id}`;
+	const events = store.events(id);
+	if (cmd.flags.json) return JSON.stringify({ fact, events }, null, 2);
+	const lines = [
+		formatFactLine(fact),
+		`status: ${fact.status}`,
+		`scope: ${JSON.stringify(fact.scope)}`,
+		`source: ${JSON.stringify(fact.source)}`,
+		`evidence: ${fact.evidence.length === 0 ? "none" : JSON.stringify(fact.evidence)}`,
+		"events:",
+		...events.map(
+			event =>
+				`- ${new Date(event.createdAt).toISOString()} ${event.action}${event.reason ? `: ${event.reason}` : ""}`,
+		),
+	];
+	return lines.join("\n");
+}
+
+function handleRetract(store: FactStore, cmd: FactsCommandArgs): string {
+	const [id, ...reasonParts] = cmd.values;
+	if (!id) throw new Error("Usage: facts retract <id> [reason]");
+	const fact = store.retract(id, reasonParts.join(" ") || undefined);
+	if (!fact) return `Fact not found: ${id}`;
+	if (cmd.flags.json) return JSON.stringify(fact, null, 2);
+	return `Retracted fact ${fact.id}`;
+}
+
+function handleErase(store: FactStore, cmd: FactsCommandArgs): string {
+	const [id, ...reasonParts] = cmd.values;
+	if (!id) throw new Error("Usage: facts erase <id> [reason]");
+	const fact = store.erase(id, reasonParts.join(" ") || undefined);
+	if (!fact) return `Fact not found: ${id}`;
+	if (cmd.flags.json) return JSON.stringify(fact, null, 2);
+	return `Erased fact ${fact.id}`;
+}
+
+function handlePrompt(store: FactStore, cmd: FactsCommandArgs): string {
+	const facts = store.list({ includeHistory: true, limit: 100 });
+	const formatted = formatKnownFactsBlock(facts, {
+		includePersonal: cmd.flags.includePersonal,
+		maxFacts: cmd.flags.limit,
+	});
+	if (cmd.flags.json) return JSON.stringify(formatted, null, 2);
+	return formatted.text || "No injectable facts.";
+}
+
+function formatFactLine(fact: FactAssertion): string {
+	return `${fact.id} [${fact.kind}/${fact.status}/${fact.sensitivity}] ${fact.subject}.${fact.predicate} — ${fact.canonicalText}`;
+}
+
+function buildScope(scopeRaw: string | undefined, cwd: string): FactScope {
+	const kind = parseScopeKind(scopeRaw);
+	if (kind === "project") return { kind, projectCwd: cwd };
+	return { kind };
+}
+
+function parseScopeKind(value: string | undefined): FactScopeKind {
+	const scope = value ?? "project";
+	if (!isFactScopeKind(scope)) {
+		throw new Error(`Invalid fact scope: ${scope}. Scopes: ${FACT_SCOPE_KINDS.join(", ")}`);
+	}
+	return scope;
+}
+
+function parseSensitivity(value: string | undefined): FactSensitivity | undefined {
+	if (!value) return undefined;
+	if (!isFactSensitivity(value)) {
+		throw new Error(`Invalid fact sensitivity: ${value}. Sensitivities: ${FACT_SENSITIVITIES.join(", ")}`);
+	}
+	return value;
+}
+
+function parseObjectValue(value: string): unknown {
+	try {
+		return JSON.parse(value);
+	} catch {
+		return value;
+	}
+}
+
+function formatObjectValue(value: unknown): string {
+	return typeof value === "string" ? value : JSON.stringify(value);
+}
+
+function readFlagValue(argv: string[], index: number, flag: string): string {
+	const value = argv[index];
+	if (!value) throw new Error(`${flag} requires a value.`);
+	return value;
+}
+
+function emit(output: string, write: ((text: string) => void) | undefined): string {
+	if (write) write(output);
+	return output;
+}

--- a/packages/coding-agent/src/commands/facts.ts
+++ b/packages/coding-agent/src/commands/facts.ts
@@ -1,0 +1,54 @@
+import { Args, Command, Flags, renderCommandHelp } from "@oh-my-pi/pi-utils/cli";
+import { type FactsAction, parseFactsArgv, runFactsCommand } from "../cli/facts-cli";
+
+const ACTIONS: FactsAction[] = ["add", "view", "search", "explain", "retract", "erase", "path", "prompt"];
+
+export default class Facts extends Command {
+	static description = "Manage local fact assertions";
+	static strict = false;
+
+	static args = {
+		action: Args.string({
+			description: "Facts action",
+			required: false,
+			options: ACTIONS,
+		}),
+		values: Args.string({
+			description: "Action values",
+			required: false,
+			multiple: true,
+		}),
+	};
+
+	static flags = {
+		json: Flags.boolean({ description: "Output JSON" }),
+		all: Flags.boolean({ description: "Include non-active facts" }),
+		"include-personal": Flags.boolean({ description: "Allow personal facts in prompt output" }),
+		scope: Flags.string({ description: "Fact scope", options: ["global", "project", "session", "task", "external"] }),
+		sensitivity: Flags.string({
+			description: "Fact sensitivity",
+			options: ["normal", "personal", "sensitive", "secret"],
+		}),
+		canonical: Flags.string({ description: "Canonical human-readable fact text" }),
+		limit: Flags.string({ description: "Maximum facts to return" }),
+		db: Flags.string({ description: "Override facts database path" }),
+	};
+
+	static examples = [
+		`oh-omp facts add project_decision project:oh-omp storage "SQLite for the manual Fact Store MVP"`,
+		`oh-omp facts view`,
+		`oh-omp facts search storage`,
+		`oh-omp facts explain fact_123`,
+		`oh-omp facts retract fact_123 "superseded by a later decision"`,
+		`oh-omp facts erase fact_123 "privacy request"`,
+	];
+
+	async run(): Promise<void> {
+		if (this.argv.length === 0) {
+			renderCommandHelp("oh-omp", "facts", Facts);
+			return;
+		}
+		const cmd = parseFactsArgv(this.argv);
+		await runFactsCommand(cmd, { write: text => process.stdout.write(`${text}\n`) });
+	}
+}

--- a/packages/coding-agent/src/facts/index.ts
+++ b/packages/coding-agent/src/facts/index.ts
@@ -1,0 +1,4 @@
+export * from "./prompt-format";
+export * from "./resolver";
+export * from "./schema";
+export * from "./storage";

--- a/packages/coding-agent/src/facts/prompt-format.ts
+++ b/packages/coding-agent/src/facts/prompt-format.ts
@@ -1,0 +1,94 @@
+import { type FactOmission, type FactResolveOptions, resolveActiveFacts } from "./resolver";
+import type { FactAssertion } from "./schema";
+
+export const DEFAULT_KNOWN_FACTS_MAX_FACTS = 5;
+export const DEFAULT_KNOWN_FACTS_MAX_CHARS = 2000;
+
+export interface KnownFactsFormatOptions extends FactResolveOptions {
+	maxFacts?: number;
+	maxChars?: number;
+	now?: Date;
+}
+
+export interface KnownFactsFormatResult {
+	text: string;
+	selected: FactAssertion[];
+	omitted: FactOmission[];
+	estimatedChars: number;
+}
+
+export function formatKnownFactsBlock(
+	facts: readonly FactAssertion[],
+	options: KnownFactsFormatOptions = {},
+): KnownFactsFormatResult {
+	const now = options.now ?? new Date(options.nowMs ?? Date.now());
+	const maxFacts = normalizePositiveInteger(options.maxFacts, DEFAULT_KNOWN_FACTS_MAX_FACTS);
+	const maxChars = normalizePositiveInteger(options.maxChars, DEFAULT_KNOWN_FACTS_MAX_CHARS);
+	const resolved = resolveActiveFacts(facts, { ...options, nowMs: now.getTime() });
+	const selected: FactAssertion[] = [];
+	const omitted: FactOmission[] = [...resolved.omitted];
+
+	const lines = [
+		`<known-facts as_of="${escapeXml(now.toISOString())}" precedence="current user instructions, repo state, runtime output, and explicit corrections outrank stored facts">`,
+	];
+	let charCount = lines[0]?.length ?? 0;
+
+	for (const fact of resolved.active) {
+		if (selected.length >= maxFacts) {
+			omitted.push({ id: fact.id, reason: "max_facts" });
+			continue;
+		}
+		const rendered = renderFact(fact);
+		const projected = charCount + rendered.length + "\n</known-facts>".length;
+		if (projected > maxChars) {
+			omitted.push({ id: fact.id, reason: "max_chars" });
+			continue;
+		}
+		lines.push(rendered);
+		charCount += rendered.length;
+		selected.push(fact);
+	}
+
+	lines.push("</known-facts>");
+	const text = selected.length === 0 ? "" : lines.join("\n");
+	return {
+		text,
+		selected,
+		omitted,
+		estimatedChars: text.length,
+	};
+}
+
+function renderFact(fact: FactAssertion): string {
+	const attrs = [
+		formatAttr("id", fact.id),
+		formatAttr("kind", fact.kind),
+		formatAttr("subject", fact.subject),
+		formatAttr("predicate", fact.predicate),
+		formatAttr("confidence", fact.confidence.toFixed(2)),
+		formatAttr("observed_at", fact.temporal.observedAt),
+		formatAttr("source", fact.source.kind),
+	];
+	if (fact.temporal.effectiveFrom) attrs.push(formatAttr("effective_from", fact.temporal.effectiveFrom));
+	if (fact.temporal.effectiveUntil) attrs.push(formatAttr("effective_until", fact.temporal.effectiveUntil));
+	if (fact.supersedes.length > 0) attrs.push(formatAttr("supersedes", fact.supersedes.join(",")));
+	return `  <fact ${attrs.join(" ")}>${escapeXml(fact.canonicalText)}</fact>`;
+}
+
+function formatAttr(name: string, value: string): string {
+	return `${name}="${escapeXml(value)}"`;
+}
+
+function escapeXml(value: string): string {
+	return value
+		.replace(/&/g, "&amp;")
+		.replace(/</g, "&lt;")
+		.replace(/>/g, "&gt;")
+		.replace(/"/g, "&quot;")
+		.replace(/'/g, "&apos;");
+}
+
+function normalizePositiveInteger(value: number | undefined, fallback: number): number {
+	if (!Number.isFinite(value ?? fallback)) return fallback;
+	return Math.max(0, Math.floor(value ?? fallback));
+}

--- a/packages/coding-agent/src/facts/resolver.ts
+++ b/packages/coding-agent/src/facts/resolver.ts
@@ -1,0 +1,131 @@
+import {
+	buildFactConflictKey,
+	type FactAssertion,
+	type FactSensitivity,
+	type FactSourceKind,
+	MIN_ACTIVE_FACT_CONFIDENCE,
+} from "./schema";
+
+export interface FactResolveOptions {
+	nowMs?: number;
+	minConfidence?: number;
+	includePersonal?: boolean;
+	includeSensitive?: boolean;
+	includeDisputed?: boolean;
+}
+
+export interface FactResolutionResult {
+	active: FactAssertion[];
+	omitted: FactOmission[];
+}
+
+export interface FactOmission {
+	id: string;
+	reason:
+		| "status"
+		| "expired"
+		| "low_confidence"
+		| "personal"
+		| "sensitive"
+		| "secret"
+		| "superseded_by_selected"
+		| "max_facts"
+		| "max_chars";
+	detail?: string;
+}
+
+const SOURCE_AUTHORITY: Record<FactSourceKind, number> = {
+	user: 6,
+	manual: 5,
+	document: 4,
+	tool: 3,
+	assistant: 2,
+	memory_extraction: 1,
+};
+
+export function resolveActiveFacts(
+	facts: readonly FactAssertion[],
+	options: FactResolveOptions = {},
+): FactResolutionResult {
+	const nowMs = options.nowMs ?? Date.now();
+	const minConfidence = options.minConfidence ?? MIN_ACTIVE_FACT_CONFIDENCE;
+	const omitted: FactOmission[] = [];
+	const grouped = new Map<string, FactAssertion[]>();
+
+	for (const fact of facts) {
+		const omitReason = getBaseOmissionReason(fact, { ...options, minConfidence, nowMs });
+		if (omitReason) {
+			omitted.push(omitReason);
+			continue;
+		}
+		const key = buildFactConflictKey(fact);
+		const list = grouped.get(key) ?? [];
+		list.push(fact);
+		grouped.set(key, list);
+	}
+
+	const active: FactAssertion[] = [];
+	for (const group of grouped.values()) {
+		const selected = [...group].sort(compareFactAuthority)[0];
+		if (!selected) continue;
+		active.push(selected);
+		for (const fact of group) {
+			if (fact.id === selected.id) continue;
+			omitted.push({ id: fact.id, reason: "superseded_by_selected", detail: selected.id });
+		}
+	}
+
+	active.sort(compareFactAuthority);
+	return { active, omitted };
+}
+
+export function isFactExpired(fact: FactAssertion, nowMs: number = Date.now()): boolean {
+	const expiresAt = fact.temporal.expiresAt ?? fact.temporal.effectiveUntil;
+	if (!expiresAt) return false;
+	const expiresMs = Date.parse(expiresAt);
+	return Number.isFinite(expiresMs) && expiresMs <= nowMs;
+}
+
+export function compareFactAuthority(a: FactAssertion, b: FactAssertion): number {
+	const sourceDelta = sourceAuthority(b.source.kind) - sourceAuthority(a.source.kind);
+	if (sourceDelta !== 0) return sourceDelta;
+
+	const confidenceDelta = b.confidence - a.confidence;
+	if (Math.abs(confidenceDelta) >= 0.0001) return confidenceDelta;
+
+	return b.updatedAt - a.updatedAt;
+}
+
+function getBaseOmissionReason(
+	fact: FactAssertion,
+	options: FactResolveOptions & { minConfidence: number; nowMs: number },
+): FactOmission | null {
+	if (fact.status === "disputed" && !options.includeDisputed) {
+		return { id: fact.id, reason: "status", detail: fact.status };
+	}
+	if (fact.status !== "active" && fact.status !== "disputed") {
+		return { id: fact.id, reason: "status", detail: fact.status };
+	}
+	if (isFactExpired(fact, options.nowMs)) {
+		return { id: fact.id, reason: "expired" };
+	}
+	if (fact.confidence < options.minConfidence) {
+		return { id: fact.id, reason: "low_confidence", detail: String(fact.confidence) };
+	}
+	return getSensitivityOmissionReason(fact.id, fact.sensitivity, options);
+}
+
+function getSensitivityOmissionReason(
+	id: string,
+	sensitivity: FactSensitivity,
+	options: FactResolveOptions,
+): FactOmission | null {
+	if (sensitivity === "secret") return { id, reason: "secret" };
+	if (sensitivity === "sensitive" && !options.includeSensitive) return { id, reason: "sensitive" };
+	if (sensitivity === "personal" && !options.includePersonal) return { id, reason: "personal" };
+	return null;
+}
+
+function sourceAuthority(kind: FactSourceKind): number {
+	return SOURCE_AUTHORITY[kind] ?? 0;
+}

--- a/packages/coding-agent/src/facts/schema.ts
+++ b/packages/coding-agent/src/facts/schema.ts
@@ -1,0 +1,254 @@
+export const FACT_KINDS = [
+	"user_preference",
+	"project_decision",
+	"project_constraint",
+	"date_deadline",
+	"ownership",
+	"environment_tooling",
+] as const;
+
+export type FactKind = (typeof FACT_KINDS)[number];
+
+export const FACT_STATUSES = ["active", "superseded", "retracted", "disputed", "expired", "erased"] as const;
+export type FactStatus = (typeof FACT_STATUSES)[number];
+
+export const FACT_SCOPE_KINDS = ["global", "project", "session", "task", "external"] as const;
+export type FactScopeKind = (typeof FACT_SCOPE_KINDS)[number];
+
+export const FACT_SOURCE_KINDS = ["user", "assistant", "tool", "document", "memory_extraction", "manual"] as const;
+export type FactSourceKind = (typeof FACT_SOURCE_KINDS)[number];
+
+export const FACT_SENSITIVITIES = ["normal", "personal", "sensitive", "secret"] as const;
+export type FactSensitivity = (typeof FACT_SENSITIVITIES)[number];
+
+export const DEFAULT_FACT_CONFIDENCE = 0.98;
+export const MIN_ACTIVE_FACT_CONFIDENCE = 0.5;
+
+const factKindSet = new Set<string>(FACT_KINDS);
+const factStatusSet = new Set<string>(FACT_STATUSES);
+const factScopeKindSet = new Set<string>(FACT_SCOPE_KINDS);
+const factSourceKindSet = new Set<string>(FACT_SOURCE_KINDS);
+const factSensitivitySet = new Set<string>(FACT_SENSITIVITIES);
+
+export interface FactScope {
+	kind: FactScopeKind;
+	projectCwd?: string;
+	repoRemote?: string;
+	branch?: string;
+	sessionId?: string;
+	taskId?: string;
+	externalId?: string;
+}
+
+export interface FactTemporal {
+	observedAt: string;
+	effectiveFrom?: string;
+	effectiveUntil?: string;
+	expiresAt?: string;
+	asOf?: string;
+}
+
+export interface FactSource {
+	kind: FactSourceKind;
+	sessionId?: string;
+	turn?: number;
+	locator?: string;
+}
+
+export interface FactEvidence {
+	locator: string;
+	quote?: string;
+}
+
+export interface FactAssertion {
+	id: string;
+	kind: FactKind;
+	subject: string;
+	predicate: string;
+	object: unknown;
+	canonicalText: string;
+	scope: FactScope;
+	temporal: FactTemporal;
+	status: FactStatus;
+	confidence: number;
+	source: FactSource;
+	evidence: FactEvidence[];
+	supersedes: string[];
+	tags: string[];
+	sensitivity: FactSensitivity;
+	createdAt: number;
+	updatedAt: number;
+}
+
+export interface NewFactAssertionInput {
+	kind: FactKind;
+	subject: string;
+	predicate: string;
+	object: unknown;
+	canonicalText: string;
+	scope: FactScope;
+	temporal?: Partial<FactTemporal>;
+	confidence?: number;
+	source?: Partial<FactSource>;
+	evidence?: FactEvidence[];
+	supersedes?: string[];
+	tags?: string[];
+	sensitivity?: FactSensitivity;
+	id?: string;
+	nowMs?: number;
+}
+
+export function isFactKind(value: unknown): value is FactKind {
+	return typeof value === "string" && factKindSet.has(value);
+}
+
+export function isFactStatus(value: unknown): value is FactStatus {
+	return typeof value === "string" && factStatusSet.has(value);
+}
+
+export function isFactScopeKind(value: unknown): value is FactScopeKind {
+	return typeof value === "string" && factScopeKindSet.has(value);
+}
+
+export function isFactSourceKind(value: unknown): value is FactSourceKind {
+	return typeof value === "string" && factSourceKindSet.has(value);
+}
+
+export function isFactSensitivity(value: unknown): value is FactSensitivity {
+	return typeof value === "string" && factSensitivitySet.has(value);
+}
+
+export function normalizeFactSubject(value: string): string {
+	return value.trim().replace(/\s+/g, " ");
+}
+
+export function normalizeFactPredicate(value: string): string {
+	return value
+		.trim()
+		.toLowerCase()
+		.replace(/[^a-z0-9_.-]+/g, "_")
+		.replace(/^_+|_+$/g, "");
+}
+
+export function normalizeScope(scope: FactScope): FactScope {
+	if (!isFactScopeKind(scope.kind)) {
+		throw new Error(`Invalid fact scope kind: ${String(scope.kind)}`);
+	}
+	return {
+		kind: scope.kind,
+		projectCwd: normalizeOptionalString(scope.projectCwd),
+		repoRemote: normalizeOptionalString(scope.repoRemote),
+		branch: normalizeOptionalString(scope.branch),
+		sessionId: normalizeOptionalString(scope.sessionId),
+		taskId: normalizeOptionalString(scope.taskId),
+		externalId: normalizeOptionalString(scope.externalId),
+	};
+}
+
+export function buildScopeKey(scope: FactScope): string {
+	const normalized = normalizeScope(scope);
+	return [
+		normalized.kind,
+		normalized.projectCwd ?? "",
+		normalized.repoRemote ?? "",
+		normalized.branch ?? "",
+		normalized.sessionId ?? "",
+		normalized.taskId ?? "",
+		normalized.externalId ?? "",
+	].join("|");
+}
+
+export function buildFactConflictKey(assertion: Pick<FactAssertion, "subject" | "predicate" | "scope">): string {
+	return `${assertion.subject}\u0000${assertion.predicate}\u0000${buildScopeKey(assertion.scope)}`;
+}
+
+export function createFactAssertion(input: NewFactAssertionInput): FactAssertion {
+	if (!isFactKind(input.kind)) {
+		throw new Error(`Invalid fact kind: ${String(input.kind)}`);
+	}
+	const subject = normalizeFactSubject(input.subject);
+	if (!subject) throw new Error("Fact subject is required.");
+
+	const predicate = normalizeFactPredicate(input.predicate);
+	if (!predicate) throw new Error("Fact predicate is required.");
+
+	const canonicalText = input.canonicalText.trim().replace(/\s+/g, " ");
+	if (!canonicalText) throw new Error("Fact canonical text is required.");
+
+	const sensitivity = input.sensitivity ?? defaultSensitivityForKind(input.kind);
+	if (!isFactSensitivity(sensitivity)) {
+		throw new Error(`Invalid fact sensitivity: ${String(sensitivity)}`);
+	}
+	if (sensitivity === "secret") {
+		throw new Error("Secret facts must not be stored.");
+	}
+
+	const confidence = input.confidence ?? DEFAULT_FACT_CONFIDENCE;
+	if (!Number.isFinite(confidence) || confidence < 0 || confidence > 1) {
+		throw new Error("Fact confidence must be a finite number between 0 and 1.");
+	}
+
+	const nowMs = input.nowMs ?? Date.now();
+	const observedAt = input.temporal?.observedAt ?? new Date(nowMs).toISOString();
+	const sourceKind = input.source?.kind ?? "manual";
+	if (!isFactSourceKind(sourceKind)) {
+		throw new Error(`Invalid fact source kind: ${String(sourceKind)}`);
+	}
+
+	return {
+		id: input.id ?? `fact_${crypto.randomUUID()}`,
+		kind: input.kind,
+		subject,
+		predicate,
+		object: input.object,
+		canonicalText,
+		scope: normalizeScope(input.scope),
+		temporal: {
+			observedAt,
+			effectiveFrom: normalizeOptionalString(input.temporal?.effectiveFrom),
+			effectiveUntil: normalizeOptionalString(input.temporal?.effectiveUntil),
+			expiresAt: normalizeOptionalString(input.temporal?.expiresAt),
+			asOf: normalizeOptionalString(input.temporal?.asOf),
+		},
+		status: "active",
+		confidence,
+		source: {
+			kind: sourceKind,
+			sessionId: normalizeOptionalString(input.source?.sessionId),
+			turn: input.source?.turn,
+			locator: normalizeOptionalString(input.source?.locator),
+		},
+		evidence: normalizeEvidence(input.evidence ?? []),
+		supersedes: normalizeStringArray(input.supersedes ?? []),
+		tags: normalizeStringArray(input.tags ?? []),
+		sensitivity,
+		createdAt: nowMs,
+		updatedAt: nowMs,
+	};
+}
+
+export function defaultSensitivityForKind(kind: FactKind): FactSensitivity {
+	return kind === "user_preference" ? "personal" : "normal";
+}
+
+export function normalizeEvidence(evidence: FactEvidence[]): FactEvidence[] {
+	return evidence
+		.map(item => ({
+			locator: item.locator.trim(),
+			quote: normalizeOptionalString(item.quote),
+		}))
+		.filter(item => item.locator.length > 0)
+		.map(item => {
+			if (!item.quote) return { locator: item.locator };
+			return { locator: item.locator, quote: item.quote.slice(0, 500) };
+		});
+}
+
+function normalizeStringArray(values: string[]): string[] {
+	return Array.from(new Set(values.map(value => value.trim()).filter(Boolean)));
+}
+
+function normalizeOptionalString(value: string | undefined): string | undefined {
+	const trimmed = value?.trim();
+	return trimmed ? trimmed : undefined;
+}

--- a/packages/coding-agent/src/facts/storage.ts
+++ b/packages/coding-agent/src/facts/storage.ts
@@ -1,0 +1,335 @@
+import { Database, type Statement } from "bun:sqlite";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { getAgentDir, logger } from "@oh-my-pi/pi-utils";
+import {
+	createFactAssertion,
+	FACT_STATUSES,
+	type FactAssertion,
+	type FactEvidence,
+	type FactScope,
+	type FactSource,
+	type FactStatus,
+	type FactTemporal,
+	type NewFactAssertionInput,
+} from "./schema";
+
+const SQLITE_NOW_EPOCH = "CAST(strftime('%s','now') AS INTEGER)";
+const FACTS_DB_FILENAME = "facts.sqlite";
+
+interface FactRow {
+	id: string;
+	kind: FactAssertion["kind"];
+	subject: string;
+	predicate: string;
+	object_json: string;
+	canonical_text: string;
+	scope_json: string;
+	temporal_json: string;
+	status: FactStatus;
+	confidence: number;
+	source_json: string;
+	evidence_json: string;
+	supersedes_json: string;
+	tags_json: string;
+	sensitivity: FactAssertion["sensitivity"];
+	created_at: number;
+	updated_at: number;
+}
+
+export interface FactListOptions {
+	includeHistory?: boolean;
+	status?: FactStatus;
+	limit?: number;
+	subject?: string;
+	predicate?: string;
+}
+
+export interface FactSearchOptions extends FactListOptions {
+	query: string;
+}
+
+export interface FactEvent {
+	id: number;
+	factId: string;
+	action: string;
+	reason?: string;
+	createdAt: number;
+}
+
+interface FactEventRow {
+	id: number;
+	fact_id: string;
+	action: string;
+	reason: string | null;
+	created_at: number;
+}
+
+export function getFactsDbPath(agentDir: string = getAgentDir()): string {
+	return path.join(agentDir, FACTS_DB_FILENAME);
+}
+
+export class FactStore {
+	#db: Database;
+	#insertStmt: Statement;
+	#getStmt: Statement;
+	#listStmt: Statement;
+	#listActiveStmt: Statement;
+	#searchStmt: Statement;
+	#searchActiveStmt: Statement;
+	#updateStatusStmt: Statement;
+	#eraseStmt: Statement;
+	#insertEventStmt: Statement;
+	#eventsStmt: Statement;
+
+	constructor(dbPath: string = getFactsDbPath()) {
+		const dir = path.dirname(dbPath);
+		fs.mkdirSync(dir, { recursive: true });
+
+		this.#db = new Database(dbPath);
+		this.#db.exec(`
+PRAGMA journal_mode=WAL;
+PRAGMA synchronous=NORMAL;
+PRAGMA busy_timeout=5000;
+
+CREATE TABLE IF NOT EXISTS fact_assertions (
+	id TEXT PRIMARY KEY,
+	kind TEXT NOT NULL,
+	subject TEXT NOT NULL,
+	predicate TEXT NOT NULL,
+	object_json TEXT NOT NULL,
+	canonical_text TEXT NOT NULL,
+	scope_json TEXT NOT NULL,
+	temporal_json TEXT NOT NULL,
+	status TEXT NOT NULL,
+	confidence REAL NOT NULL,
+	source_json TEXT NOT NULL,
+	evidence_json TEXT NOT NULL,
+	supersedes_json TEXT NOT NULL DEFAULT '[]',
+	tags_json TEXT NOT NULL DEFAULT '[]',
+	sensitivity TEXT NOT NULL,
+	created_at INTEGER NOT NULL DEFAULT (${SQLITE_NOW_EPOCH}),
+	updated_at INTEGER NOT NULL DEFAULT (${SQLITE_NOW_EPOCH})
+);
+CREATE INDEX IF NOT EXISTS idx_fact_assertions_status ON fact_assertions(status);
+CREATE INDEX IF NOT EXISTS idx_fact_assertions_kind ON fact_assertions(kind);
+CREATE INDEX IF NOT EXISTS idx_fact_assertions_subject ON fact_assertions(subject);
+CREATE INDEX IF NOT EXISTS idx_fact_assertions_predicate ON fact_assertions(predicate);
+CREATE INDEX IF NOT EXISTS idx_fact_assertions_updated ON fact_assertions(updated_at DESC);
+
+CREATE TABLE IF NOT EXISTS fact_events (
+	id INTEGER PRIMARY KEY AUTOINCREMENT,
+	fact_id TEXT NOT NULL,
+	action TEXT NOT NULL,
+	reason TEXT,
+	created_at INTEGER NOT NULL DEFAULT (${SQLITE_NOW_EPOCH})
+);
+CREATE INDEX IF NOT EXISTS idx_fact_events_fact ON fact_events(fact_id, created_at DESC);
+`);
+		this.#insertStmt = this.#db.prepare(`
+INSERT INTO fact_assertions (
+	id, kind, subject, predicate, object_json, canonical_text, scope_json, temporal_json,
+	status, confidence, source_json, evidence_json, supersedes_json, tags_json, sensitivity,
+	created_at, updated_at
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+`);
+		this.#getStmt = this.#db.prepare("SELECT * FROM fact_assertions WHERE id = ?");
+		this.#listStmt = this.#db.prepare(
+			"SELECT * FROM fact_assertions ORDER BY updated_at DESC, created_at DESC LIMIT ?",
+		);
+		this.#listActiveStmt = this.#db.prepare(
+			"SELECT * FROM fact_assertions WHERE status = 'active' ORDER BY updated_at DESC, created_at DESC LIMIT ?",
+		);
+		this.#searchStmt = this.#db.prepare(`
+SELECT * FROM fact_assertions
+WHERE subject LIKE ? ESCAPE '\\'
+	OR predicate LIKE ? ESCAPE '\\'
+	OR canonical_text LIKE ? ESCAPE '\\'
+ORDER BY updated_at DESC, created_at DESC
+LIMIT ?
+`);
+		this.#searchActiveStmt = this.#db.prepare(`
+SELECT * FROM fact_assertions
+WHERE status = 'active'
+	AND (subject LIKE ? ESCAPE '\\'
+		OR predicate LIKE ? ESCAPE '\\'
+		OR canonical_text LIKE ? ESCAPE '\\')
+ORDER BY updated_at DESC, created_at DESC
+LIMIT ?
+`);
+		this.#updateStatusStmt = this.#db.prepare("UPDATE fact_assertions SET status = ?, updated_at = ? WHERE id = ?");
+		this.#eraseStmt = this.#db.prepare(`
+UPDATE fact_assertions
+SET subject = '[erased]', predicate = 'erased', object_json = 'null', canonical_text = '[erased]',
+	evidence_json = '[]', supersedes_json = '[]', tags_json = '[]', status = 'erased', sensitivity = 'sensitive', updated_at = ?
+WHERE id = ?
+`);
+		this.#insertEventStmt = this.#db.prepare(
+			"INSERT INTO fact_events (fact_id, action, reason, created_at) VALUES (?, ?, ?, ?)",
+		);
+		this.#eventsStmt = this.#db.prepare(
+			"SELECT * FROM fact_events WHERE fact_id = ? ORDER BY created_at DESC, id DESC",
+		);
+	}
+
+	static open(dbPath?: string): FactStore {
+		return new FactStore(dbPath);
+	}
+
+	close(): void {
+		this.#db.close();
+	}
+
+	add(input: NewFactAssertionInput): FactAssertion {
+		const assertion = createFactAssertion(input);
+		this.insert(assertion);
+		return assertion;
+	}
+
+	insert(assertion: FactAssertion): void {
+		const transaction = this.#db.transaction(() => {
+			this.#insertStmt.run(
+				assertion.id,
+				assertion.kind,
+				assertion.subject,
+				assertion.predicate,
+				JSON.stringify(assertion.object),
+				assertion.canonicalText,
+				JSON.stringify(assertion.scope),
+				JSON.stringify(assertion.temporal),
+				assertion.status,
+				assertion.confidence,
+				JSON.stringify(assertion.source),
+				JSON.stringify(assertion.evidence),
+				JSON.stringify(assertion.supersedes),
+				JSON.stringify(assertion.tags),
+				assertion.sensitivity,
+				Math.floor(assertion.createdAt / 1000),
+				Math.floor(assertion.updatedAt / 1000),
+			);
+			this.#recordEvent(assertion.id, "add", undefined, assertion.createdAt);
+		});
+		transaction();
+	}
+
+	get(id: string): FactAssertion | null {
+		const row = this.#getStmt.get(id) as FactRow | undefined;
+		return row ? rowToFact(row) : null;
+	}
+
+	list(options: FactListOptions = {}): FactAssertion[] {
+		const limit = normalizeLimit(options.limit);
+		let rows: FactRow[];
+		if (options.status) {
+			if (!FACT_STATUSES.includes(options.status)) return [];
+			rows = this.#db
+				.prepare("SELECT * FROM fact_assertions WHERE status = ? ORDER BY updated_at DESC, created_at DESC LIMIT ?")
+				.all(options.status, limit) as FactRow[];
+		} else if (options.includeHistory) {
+			rows = this.#listStmt.all(limit) as FactRow[];
+		} else {
+			rows = this.#listActiveStmt.all(limit) as FactRow[];
+		}
+		return rows.map(rowToFact).filter(fact => matchesListOptions(fact, options));
+	}
+
+	search(options: FactSearchOptions): FactAssertion[] {
+		const query = options.query.trim();
+		if (!query) return [];
+		const limit = normalizeLimit(options.limit);
+		const pattern = `%${escapeLike(query)}%`;
+		const rows = (
+			options.includeHistory
+				? this.#searchStmt.all(pattern, pattern, pattern, limit)
+				: this.#searchActiveStmt.all(pattern, pattern, pattern, limit)
+		) as FactRow[];
+		return rows.map(rowToFact).filter(fact => matchesListOptions(fact, options));
+	}
+
+	retract(id: string, reason?: string, nowMs: number = Date.now()): FactAssertion | null {
+		const existing = this.get(id);
+		if (!existing || existing.status === "erased") return existing;
+		const nowSec = Math.floor(nowMs / 1000);
+		const transaction = this.#db.transaction(() => {
+			this.#updateStatusStmt.run("retracted", nowSec, id);
+			this.#recordEvent(id, "retract", reason, nowMs);
+		});
+		transaction();
+		return this.get(id);
+	}
+
+	erase(id: string, reason?: string, nowMs: number = Date.now()): FactAssertion | null {
+		const existing = this.get(id);
+		if (!existing) return null;
+		const nowSec = Math.floor(nowMs / 1000);
+		const transaction = this.#db.transaction(() => {
+			this.#eraseStmt.run(nowSec, id);
+			this.#recordEvent(id, "erase", reason, nowMs);
+		});
+		transaction();
+		return this.get(id);
+	}
+
+	events(factId: string): FactEvent[] {
+		const rows = this.#eventsStmt.all(factId) as FactEventRow[];
+		return rows.map(row => ({
+			id: row.id,
+			factId: row.fact_id,
+			action: row.action,
+			reason: row.reason ?? undefined,
+			createdAt: row.created_at * 1000,
+		}));
+	}
+
+	#recordEvent(factId: string, action: string, reason: string | undefined, nowMs: number): void {
+		this.#insertEventStmt.run(factId, action, reason ?? null, Math.floor(nowMs / 1000));
+	}
+}
+
+function rowToFact(row: FactRow): FactAssertion {
+	return {
+		id: row.id,
+		kind: row.kind,
+		subject: row.subject,
+		predicate: row.predicate,
+		object: parseJson(row.object_json, null),
+		canonicalText: row.canonical_text,
+		scope: parseJson(row.scope_json, { kind: "global" }) as FactScope,
+		temporal: parseJson(row.temporal_json, {
+			observedAt: new Date(row.created_at * 1000).toISOString(),
+		}) as FactTemporal,
+		status: row.status,
+		confidence: row.confidence,
+		source: parseJson(row.source_json, { kind: "manual" }) as FactSource,
+		evidence: parseJson(row.evidence_json, []) as FactEvidence[],
+		supersedes: parseJson(row.supersedes_json, []) as string[],
+		tags: parseJson(row.tags_json, []) as string[],
+		sensitivity: row.sensitivity,
+		createdAt: row.created_at * 1000,
+		updatedAt: row.updated_at * 1000,
+	};
+}
+
+function parseJson(value: string, fallback: unknown): unknown {
+	try {
+		return JSON.parse(value);
+	} catch (error) {
+		logger.warn("FactStore JSON parse failed", { error: error instanceof Error ? error.message : String(error) });
+		return fallback;
+	}
+}
+
+function normalizeLimit(limit: number | undefined): number {
+	if (!Number.isFinite(limit ?? 50)) return 50;
+	return Math.min(Math.max(Math.floor(limit ?? 50), 0), 500);
+}
+
+function escapeLike(value: string): string {
+	return value.replace(/[\\%_]/g, match => `\\${match}`);
+}
+
+function matchesListOptions(fact: FactAssertion, options: FactListOptions): boolean {
+	if (options.subject && fact.subject !== options.subject) return false;
+	if (options.predicate && fact.predicate !== options.predicate) return false;
+	return true;
+}

--- a/packages/coding-agent/src/index.ts
+++ b/packages/coding-agent/src/index.ts
@@ -31,6 +31,7 @@ export * from "./extensibility/extensions";
 export * from "./extensibility/skills";
 // Slash commands
 export { type FileSlashCommand, loadSlashCommands as discoverSlashCommands } from "./extensibility/slash-commands";
+export * from "./facts";
 export type * from "./lsp";
 // Main entry point
 export * from "./main";

--- a/packages/coding-agent/src/modes/controllers/command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/command-controller.ts
@@ -14,6 +14,7 @@ import { Loader, Markdown, padding, Spacer, Text, visibleWidth } from "@oh-my-pi
 import { formatDuration, Snowflake, setProjectDir } from "@oh-my-pi/pi-utils";
 import { $ } from "bun";
 import { reset as resetCapabilities } from "../../capability";
+import { parseFactsArgv, runFactsCommand } from "../../cli/facts-cli";
 import type { RecallDebugEntry, RecallDebugTrace } from "../../context/recall";
 import { clearClaudePluginRootsCache } from "../../discovery/helpers";
 import { loadCustomShare } from "../../export/custom-share";
@@ -34,6 +35,7 @@ import { outputMeta } from "../../tools/output-meta";
 import { resolveToCwd, stripOuterDoubleQuotes } from "../../tools/path-utils";
 import { replaceTabs } from "../../tools/render-utils";
 import { getChangelogPath, parseChangelog } from "../../utils/changelog";
+import { parseCommandArgs } from "../../utils/command-args";
 import { openPath } from "../../utils/open";
 import { setSessionTerminalTitle } from "../../utils/title-generator";
 
@@ -716,6 +718,23 @@ export class CommandController {
 		}
 
 		this.ctx.showWarning("Usage: /recall <last|why|prompt|trace|history|help>");
+	}
+
+	async handleFactsCommand(text: string): Promise<void> {
+		const argumentText = text.slice(6).trim();
+		try {
+			const cmd = parseFactsArgv(parseCommandArgs(argumentText));
+			const output = await runFactsCommand(cmd, {
+				agentDir: this.ctx.settings.getAgentDir(),
+				cwd: this.ctx.sessionManager.getCwd(),
+			});
+			const sanitized = replaceTabs(output);
+			const displayed = sanitized.length > 20_000 ? `${sanitized.slice(0, 20_000)}\n... truncated ...` : sanitized;
+			showMarkdownPanel(this.ctx, "Facts", `\`\`\`text\n${displayed}\n\`\`\``);
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error);
+			this.ctx.showError(`Facts command failed: ${replaceTabs(message)}`);
+		}
 	}
 
 	async handleMemoryCommand(text: string): Promise<void> {

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -1243,6 +1243,10 @@ export class InteractiveMode implements InteractiveModeContext {
 		return this.#commandController.handleMoveCommand(targetPath);
 	}
 
+	handleFactsCommand(text: string): Promise<void> {
+		return this.#commandController.handleFactsCommand(text);
+	}
+
 	handleMemoryCommand(text: string): Promise<void> {
 		return this.#commandController.handleMemoryCommand(text);
 	}

--- a/packages/coding-agent/src/modes/types.ts
+++ b/packages/coding-agent/src/modes/types.ts
@@ -187,6 +187,7 @@ export interface InteractiveModeContext {
 	handleCompactCommand(customInstructions?: string): Promise<void>;
 	handleHandoffCommand(customInstructions?: string): Promise<void>;
 	handleMoveCommand(targetPath: string): Promise<void>;
+	handleFactsCommand(text: string): Promise<void>;
 	handleMemoryCommand(text: string): Promise<void>;
 	handleRecallCommand(text: string): Promise<void>;
 	handleSTTToggle(): Promise<void>;

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -577,6 +577,24 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<BuiltinSlashCommandSpec> = [
 		},
 	},
 	{
+		name: "facts",
+		description: "Manage local fact assertions",
+		subcommands: [
+			{ name: "add", description: "Add a manual fact", usage: "add <kind> <subject> <predicate> <value>" },
+			{ name: "view", description: "List active facts" },
+			{ name: "search", description: "Search facts", usage: "search <query>" },
+			{ name: "explain", description: "Explain a fact with provenance", usage: "explain <id>" },
+			{ name: "retract", description: "Retract a fact but preserve history", usage: "retract <id> [reason]" },
+			{ name: "erase", description: "Erase/redact a fact payload", usage: "erase <id> [reason]" },
+			{ name: "prompt", description: "Preview known-facts prompt block" },
+		],
+		allowArgs: true,
+		handle: async (command, runtime) => {
+			runtime.ctx.editor.setText("");
+			await runtime.ctx.handleFactsCommand(command.text);
+		},
+	},
+	{
 		name: "memory",
 		description: "Inspect and operate memory maintenance",
 		subcommands: [

--- a/packages/coding-agent/test/facts.test.ts
+++ b/packages/coding-agent/test/facts.test.ts
@@ -1,0 +1,169 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { parseFactsArgv, runFactsCommand } from "../src/cli/facts-cli";
+import { formatKnownFactsBlock } from "../src/facts/prompt-format";
+import { resolveActiveFacts } from "../src/facts/resolver";
+import { createFactAssertion } from "../src/facts/schema";
+import { FactStore } from "../src/facts/storage";
+
+let tempDir = "";
+
+afterEach(async () => {
+	if (tempDir) {
+		await fs.rm(tempDir, { recursive: true, force: true });
+		tempDir = "";
+	}
+});
+
+async function makeDbPath(): Promise<string> {
+	tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-facts-"));
+	return path.join(tempDir, "facts.sqlite");
+}
+
+describe("fact assertions", () => {
+	it("normalizes allowlisted manual facts and rejects secrets", () => {
+		const fact = createFactAssertion({
+			kind: "project_decision",
+			subject: " project:oh-omp ",
+			predicate: "Storage Choice",
+			object: "SQLite",
+			canonicalText: "Use SQLite for the manual Fact Store MVP.",
+			scope: { kind: "project", projectCwd: "/repo" },
+			nowMs: 1_700_000_000_000,
+		});
+
+		expect(fact.subject).toBe("project:oh-omp");
+		expect(fact.predicate).toBe("storage_choice");
+		expect(fact.sensitivity).toBe("normal");
+		expect(fact.temporal.observedAt).toBe("2023-11-14T22:13:20.000Z");
+		expect(() =>
+			createFactAssertion({
+				kind: "project_decision",
+				subject: "project:oh-omp",
+				predicate: "token",
+				object: "secret",
+				canonicalText: "Store a secret.",
+				scope: { kind: "project" },
+				sensitivity: "secret",
+			}),
+		).toThrow("Secret facts must not be stored");
+	});
+
+	it("stores, searches, retracts, and erases facts with explainable events", async () => {
+		const dbPath = await makeDbPath();
+		const store = FactStore.open(dbPath);
+		try {
+			const fact = store.add({
+				kind: "environment_tooling",
+				subject: "project:oh-omp",
+				predicate: "runtime",
+				object: "Bun",
+				canonicalText: "oh-omp uses Bun for TypeScript tooling.",
+				scope: { kind: "project", projectCwd: "/repo" },
+				evidence: [{ locator: "file://package.json", quote: "bun run" }],
+			});
+
+			expect(store.list()).toHaveLength(1);
+			expect(store.search({ query: "Bun" }).map(row => row.id)).toEqual([fact.id]);
+
+			const retracted = store.retract(fact.id, "superseded");
+			expect(retracted?.status).toBe("retracted");
+			expect(store.list()).toHaveLength(0);
+			expect(store.events(fact.id).map(event => event.action)).toEqual(["retract", "add"]);
+
+			const erased = store.erase(fact.id, "privacy");
+			expect(erased?.status).toBe("erased");
+			expect(erased?.canonicalText).toBe("[erased]");
+			expect(erased?.evidence).toEqual([]);
+			expect(erased?.subject).toBe("[erased]");
+			expect(erased?.predicate).toBe("erased");
+		} finally {
+			store.close();
+		}
+	});
+
+	it("resolves active facts by source authority and omits unsafe prompt facts", () => {
+		const assistantFact = createFactAssertion({
+			id: "fact_assistant",
+			kind: "project_decision",
+			subject: "project:alpha",
+			predicate: "launch_date",
+			object: "April 5",
+			canonicalText: "Project Alpha launches April 5.",
+			scope: { kind: "project", projectCwd: "/alpha" },
+			source: { kind: "assistant" },
+			nowMs: 1_700_000_000_000,
+		});
+		const userFact = createFactAssertion({
+			id: "fact_user",
+			kind: "project_decision",
+			subject: "project:alpha",
+			predicate: "launch_date",
+			object: "May 1",
+			canonicalText: "Project Alpha launches May 1.",
+			scope: { kind: "project", projectCwd: "/alpha" },
+			source: { kind: "user" },
+			nowMs: 1_700_000_001_000,
+		});
+		const personalFact = createFactAssertion({
+			id: "fact_personal",
+			kind: "user_preference",
+			subject: "user",
+			predicate: "response_style",
+			object: "concise",
+			canonicalText: "User prefers concise answers.",
+			scope: { kind: "global" },
+		});
+
+		const resolved = resolveActiveFacts([assistantFact, userFact, personalFact]);
+		expect(resolved.active.map(fact => fact.id)).toEqual(["fact_user"]);
+		expect(resolved.omitted).toContainEqual({ id: "fact_personal", reason: "personal" });
+		expect(resolved.omitted).toContainEqual({
+			id: "fact_assistant",
+			reason: "superseded_by_selected",
+			detail: "fact_user",
+		});
+
+		const formatted = formatKnownFactsBlock([assistantFact, userFact, personalFact], { maxFacts: 1 });
+		expect(formatted.text).toContain("<known-facts");
+		expect(formatted.text).toContain("Project Alpha launches May 1.");
+		expect(formatted.text).not.toContain("concise answers");
+	});
+
+	it("supports manual facts command flows without autonomous extraction", async () => {
+		const dbPath = await makeDbPath();
+		const added = await runFactsCommand(
+			{
+				action: "add",
+				values: ["project_constraint", "project:oh-omp", "collection", "manual-only first slice"],
+				flags: { db: dbPath, json: true, scope: "project" },
+			},
+			{ cwd: "/repo" },
+		);
+		const parsed = JSON.parse(added) as { id: string; canonicalText: string };
+		expect(parsed.canonicalText).toContain("manual-only first slice");
+
+		const search = await runFactsCommand(
+			{ action: "search", values: ["manual-only"], flags: { db: dbPath, json: true } },
+			{ cwd: "/repo" },
+		);
+		expect(JSON.parse(search)).toHaveLength(1);
+
+		const retracted = await runFactsCommand(
+			{ action: "retract", values: [parsed.id, "changed"], flags: { db: dbPath, json: true } },
+			{ cwd: "/repo" },
+		);
+		expect(JSON.parse(retracted).status).toBe("retracted");
+
+		const parsedFlagValue = parseFactsArgv([
+			"add",
+			"environment_tooling",
+			"project:oh-omp",
+			"required_flag",
+			"--strict",
+		]);
+		expect(parsedFlagValue.values).toEqual(["environment_tooling", "project:oh-omp", "required_flag", "--strict"]);
+	});
+});


### PR DESCRIPTION
## What

Adds the first, conservative slice of a dedicated Fact Store for `packages/coding-agent`:

- Adds ADR 0005 documenting the Fact Store as a separate belief layer from recall and memory.
- Adds `packages/coding-agent/src/facts/` with:
  - allowlisted fact kinds and schema validation
  - local SQLite assertion/event storage
  - resolver-on-read active fact selection
  - `retract` vs `erase` semantics
  - bounded `<known-facts>` prompt formatting
- Adds manual command surfaces:
  - `oh-omp facts add|view|search|explain|retract|erase|path|prompt`
  - interactive `/facts ...` with the same core command behavior
- Exports the facts module and adds focused coverage for the new contracts.

## Why

Recall stores evidence-shaped context and memory stores synthesized guidance, but neither is a good authority model for current scoped beliefs like project decisions, constraints, owners, dates, or explicit user preferences.

This PR introduces a small, inspectable, correctable Fact Store without changing the existing recall/memory contracts or replacing context assembly behavior.

## Scope and Safety

This is intentionally **manual-only**:

- No autonomous extraction.
- No auto-promotion from `.oh/*.md`, assistant plans, or session summaries.
- No `fact_current` materialized table; active facts resolve on read while rules are still stabilizing.
- No default assembly injection; the PR only adds a bounded formatter/preview path.

Privacy/safety guardrails included here:

- `secret` facts are rejected by the schema.
- `personal` and `sensitive` facts are omitted from known-facts formatting unless explicitly allowed.
- `erase` redacts payload-bearing fields, including subject, predicate, object, canonical text, evidence, supersession, and tags.
- Known-facts formatting has max fact/max character caps and includes an explicit precedence note that current user instructions, repo state, runtime output, and explicit corrections outrank stored facts.

## Testing

- `bun test packages/coding-agent/test/facts.test.ts`
  - 4 pass
  - 25 assertions
- `bun check:ts`
  - Biome check passed
  - `tsgo -p tsconfig.json` passed
- Manual smoke-tested `oh-omp facts add/search` with a temporary SQLite database.
- Regression-covered review findings:
  - erase redacts subject/predicate
  - dash-prefixed values like `--strict` can be stored as fact values when command flags precede fact fields

---

- [x] `bun check:ts` passes
- [x] Tested locally
- [ ] CHANGELOG updated (not included in this slice; flagging for maintainer decision because this adds a CLI surface)
